### PR TITLE
Fix documentation example for .github/svgo-action.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning].
 - Configure the SVGO options file. ([#99])
 - Fix `required` value for "configuration-path" input. ([#100])
 - Fix interpretation of "dry-run" input in config file. ([#103])
+- Fix documentation for configuration in config file. ([#108])
 
 ## [0.2.1] - 2020-03-02
 
@@ -62,3 +63,4 @@ Versioning].
 [#99]: https://github.com/ericcornelissen/svgo-action/pull/99
 [#100]: https://github.com/ericcornelissen/svgo-action/pull/100
 [#103]: https://github.com/ericcornelissen/svgo-action/pull/103
+[#108]: https://github.com/ericcornelissen/svgo-action/pull/108

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ can add a file called `svgo-action.yml` inside the `.github` directory. Then,
 you can configure the Action inside this file. For example:
 
 ```yaml
-- dry-run: true
-- svgo-options: "path/to/svgo-options.yml"
+dry-run: true
+svgo-options: "path/to/svgo-options.yml"
 ```
 
 #### In Another Configuration File


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

The documentation [example for what `.github/svgo-action.yml` should look like](https://github.com/ericcornelissen/svgo-action/tree/v0.2.1#in-githubsvgo-actionyml) was incorrect, and defining the configuration file in that way will not actually configure the action.