### PR TITLE
Remove the 'more options' notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ There are a couple of ways for you to configure the Action. You can configure it
 [in the Workflow file], [in `.github/svgo-action.yml`], or [in another
 configuration file]. Below you can find the available options.
 
-> :information_source: In the future the action will have more options. See
-> [#17] for progress in this regard.
-
 - `commit`: configure the commit message for the Action.
   - [Full documentation](docs/configuring-the-commit.md)
 - `conventional-commits`: Use [conventional commit] message titles for commits.
@@ -160,5 +157,4 @@ jobs:
 [in the Workflow file]: #in-the-workflow-file
 [in `.github/svgo-action.yml`]: #in-githubsvgo-actionyml
 [in another configuration file]: #in-another-configuration-file
-[#17]: https://github.com/ericcornelissen/svgo-action/issues/17
 [conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- ~~I left no linting errors in my changes.~~
- ~~I tested my changes.~~
- [x] I updated the documentation according to my changes.
- ~~I added my change to the Changelog.~~

### Description

Removes the notice from the README that informs that more options are to come. There is only one more option coming now and there are already for options there, so it seems a little redundant at this point.
