### PR TITLE
Keep lib/index.js up-to-date on the develop branch

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -1,0 +1,25 @@
+name: Update lib/index.js
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build-and-update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - run: npm ci
+    - run: npm run build
+    - name: Push updates
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "chore: update lib/index.js"
+        commit_user_name: github-actions[bot]
+        commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+        commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- ~~I left no linting errors in my changes.~~
- [x] I tested my changes.
- ~~I updated the documentation according to my changes.~~
- ~~I added my change to the Changelog.~~

### Description

Add a new GitHub Actions workflow file that, for commits on the `develop` branch, will build `lib/index.js` and push it back if it changed. This way the `lib/index.js` file will always be up-to-date on the `develop` branch no matter what happens. If the last Pull Request that gets merged doesn't change the `lib/index.js` file the Action will not push a commit and exit without an error.

