### PR TITLE
Improve options documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Improve options documentation. ([#251])
 
 ## [1.1.0] - 2020-09-02
 
@@ -156,3 +156,4 @@ Versioning].
 [#239]: https://github.com/ericcornelissen/svgo-action/pull/239
 [#245]: https://github.com/ericcornelissen/svgo-action/pull/245
 [#247]: https://github.com/ericcornelissen/svgo-action/pull/247
+[#251]: https://github.com/ericcornelissen/svgo-action/pull/251

--- a/docs/options.md
+++ b/docs/options.md
@@ -6,7 +6,7 @@ This file contains the documentation for all options for the SVGO Action.
 - [Commit](#commit)
 - [Configuration Path](#configuration-path)
 - [Conventional Commits](#conventional-commits)
-- [Dry-run](#dry-run)
+- [Dry run](#dry-run)
 - [Ignore](#ignore)
 - [SVGO Options](#svgo-options)
 
@@ -240,13 +240,13 @@ To enable conventional commit titles:
 
 ---
 
-## Dry-run
+## Dry run
 
 | Name      | Default Value | Workflow file      | Config File        |
 | --------- | ------------- | ------------------ | ------------------ |
 | `dry-run` | `false`       | :heavy_check_mark: | :heavy_check_mark: |
 
-The _dry-run_ option can be used to run the Action without having it make any
+The _dry run_ option can be used to run the Action without having it make any
 commits to your repository. This can be useful for debugging or when you just
 want to give the Action a try.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -219,7 +219,7 @@ To enable comments by the Action:
 
 | Name                   | Default Value | Workflow file      | Config File |
 | ---------------------- | ------------- | ------------------ | ----------- |
-| `conventional-commits` | `true`        | :heavy_check_mark: | :x:         |
+| `conventional-commits` | `false`       | :heavy_check_mark: | :x:         |
 
 The _conventional commits_ option can be used to enable [conventional commit]
 message titles for commits.

--- a/docs/options.md
+++ b/docs/options.md
@@ -91,7 +91,6 @@ as described in [the templating documentation].
 
 ```yaml
 # .github/svgo-action.yml
-
 commit:
   title: This will be the commit message title
 ```
@@ -117,7 +116,6 @@ message `body`, but the `title` value will be ignored.
 
 ```yaml
 # .github/svgo-action.yml
-
 commit:
   conventional: true
   title: This will be ignored
@@ -140,7 +138,6 @@ can be a template string as described in [the templating documentation].
 
 ```yaml
 # .github/svgo-action.yml
-
 commit:
   body: This will be the commit message body
 ```
@@ -160,7 +157,6 @@ multiline strings].
 
 ```yaml
 # .github/svgo-action.yml
-
 commit:
   body: |
     If you want a commit message that is a
@@ -185,7 +181,6 @@ empty string.
 
 ```yaml
 # .github/svgo-action.yml
-
 commit:
   body: ""
 ```
@@ -213,7 +208,6 @@ To enable comments by the Action:
 
 ```yaml
 # .github/workflows/svgo.yml
-
 - uses: ericcornelissen/svgo-action@latest
   with:
     configuration-path: path/to/configuration/file.yml
@@ -239,7 +233,6 @@ To enable conventional commit titles:
 
 ```yaml
 # .github/workflows/svgo.yml
-
 - uses: ericcornelissen/svgo-action@latest
   with:
     conventional-commits: true

--- a/docs/options.md
+++ b/docs/options.md
@@ -4,6 +4,7 @@ This file contains the documentation for all options for the SVGO Action.
 
 - [Comment](#comment)
 - [Commit](#commit)
+- [Configuration Path](#configuration-path)
 - [Conventional Commits](#conventional-commits)
 - [Dry-run](#dry-run)
 - [Ignore](#ignore)
@@ -197,6 +198,29 @@ Optimize 42 SVG(s) with SVGO
 
 ---
 
+## Configuration Path
+
+| Name                 | Default Value               | Workflow file      | Config File |
+| -------------------- | --------------------------- | ------------------ | ----------- |
+| `configuration-path` | `".github/svgo-action.yml"` | :heavy_check_mark: | :x:         |
+
+The _configuration path_ option can be used to change the location of the
+[configuration file].
+
+### Examples
+
+To enable comments by the Action:
+
+```yaml
+# .github/workflows/svgo.yml
+
+- uses: ericcornelissen/svgo-action@latest
+  with:
+    configuration-path: path/to/configuration/file.yml
+```
+
+---
+
 ## Conventional Commits
 
 The _conventional commits_ option can be used to enable [conventional commit]
@@ -317,6 +341,7 @@ To change the SVGO configuration file:
 svgo-options: my-svgo-options.yml
 ```
 
+[configuration file]: https://github.com/ericcornelissen/svgo-action#in-another-configuration-file
 [conventional commit]: https://www.conventionalcommits.org/
 [glob]: https://en.wikipedia.org/wiki/Glob_(programming)
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new

--- a/docs/options.md
+++ b/docs/options.md
@@ -269,9 +269,9 @@ dry-run: true
 
 ## Ignore
 
-| Name      | Default Value | Workflow file      | Config File        |
-| --------- | ------------- | ------------------ | ------------------ |
-| `ignored` | `""`          | :heavy_check_mark: | :heavy_check_mark: |
+| Name     | Default Value | Workflow file      | Config File        |
+| -------- | ------------- | ------------------ | ------------------ |
+| `ignore` | `""`          | :heavy_check_mark: | :heavy_check_mark: |
 
 The _ignore_ option allows you to specify what files should be ignored by the
 Action. By default, no files are ignored. The value is interpreted as a [glob].

--- a/docs/options.md
+++ b/docs/options.md
@@ -223,6 +223,10 @@ To enable comments by the Action:
 
 ## Conventional Commits
 
+| Name                   | Default Value | Workflow file      | Config File |
+| ---------------------- | ------------- | ------------------ | ----------- |
+| `conventional-commits` | `true`        | :heavy_check_mark: | :x:         |
+
 The _conventional commits_ option can be used to enable [conventional commit]
 message titles for commits.
 
@@ -235,13 +239,10 @@ To enable conventional commit titles:
 
 ```yaml
 # .github/workflows/svgo.yml
+
 - uses: ericcornelissen/svgo-action@latest
   with:
     conventional-commits: true
-
-
-# .github/svgo-action.yml
-conventional-commits: true
 ```
 
 ---


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

This improves the options documentation

- Add documentation for the `configuration-path` option
- Add overview table for the `conventional-commits` option
- Fix mistake for `conventional-commits` option, cannot be used in the config file
- Make options examples consistents
- Fix name of the `ignore` option
