### PR TITLE
Add possibility to include warnings in messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add warnings to commit messages and Pull Request comments. ([#258])
 
 ## [1.1.1] - 2020-09-11
 
@@ -163,3 +163,4 @@ Versioning].
 [#247]: https://github.com/ericcornelissen/svgo-action/pull/247
 [#251]: https://github.com/ericcornelissen/svgo-action/pull/251
 [#255]: https://github.com/ericcornelissen/svgo-action/pull/255
+[#258]: https://github.com/ericcornelissen/svgo-action/pull/258

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -16,6 +16,13 @@ SVGs, into these messages.
 | `optimizedCount` | The number of optimized SVGs              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `skippedCount`   | The number of not-optimized SVGs          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `svgCount`       | The number of SVGs found in the PR        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| `warnings`       | A list of warnings that occurred          | :x:                | :heavy_check_mark: | :heavy_check_mark: |
+
+It is generally recommended to include `{{warnings}}` in either the commit body
+or Pull Request comment as it will alert you about any unexpected issues that
+occurred during a run. Note that, if there are no issues, `{{warnings}}` will be
+replaced by an empty string. Alternatively, you could rely on GitHub Action Logs
+to inform you about the issues that would be reported by `{{warnings}}`.
 
 ## Examples
 
@@ -33,9 +40,11 @@ commit:
     Details:
     {{fileCount}} file(s) in PR, {{svgCount}} SVG(s),
     {{skippedCount}} SVG(s) already optimized
+
+    {{warnings}}
 ```
 
-This will result in commit messages that look like:
+This will result in commit messages that look like (assuming no warnings):
 
 ```git
 Optimized 3/4 SVG(s)
@@ -59,9 +68,11 @@ comment: |
   {{optimizedCount}} SVG(s) were optimized! Here are some statistics:
 
   {{filesTable}}
+
+  {{warnings}}
 ```
 
-This will result in comment that look like:
+This will result in comment that look like (assuming no warnings):
 
 ---
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,13 +23,15 @@ export const ENABLE_PATTERN = /enable-svgo-action/;
 export const CONVENTIONAL_COMMIT_TITLE =
   "chore: optimize {{optimizedCount}} SVG(s)";
 export const DEFAULT_COMMIT_BODY =
-  "Optimized SVG(s):\n{{filesList}}";
+  "Optimized SVG(s):\n{{filesList}}\n\n{{warnings}}";
 export const DEFAULT_COMMIT_TITLE =
   "Optimize {{optimizedCount}} SVG(s) with SVGO";
 export const DEFAULT_COMMENT = `
   SVG(s) automatically optimized using [SVGO] :sparkles:
 
   {{filesTable}}
+
+  {{warnings}}
 
   [SVGO]: https://github.com/svg/svgo
 `;

--- a/src/events/helpers.ts
+++ b/src/events/helpers.ts
@@ -24,8 +24,7 @@ async function getSvgsContent(
   client: Octokit,
   svgList: GitFileInfo[],
 ): Promise<{ svgs: FileData[], warnings: string[] }> {
-  const svgs: FileData[] = [];
-  const warnings: string[] = [];
+  const svgs: FileData[] = [], warnings: string[] = [];
   for (const svg of svgList) {
     try {
       core.debug(`fetching file contents of '${svg.path}'`);
@@ -39,9 +38,10 @@ async function getSvgsContent(
         originalEncoding: fileData.encoding,
         path: fileData.path,
       });
-    } catch (err) {
-      core.warning(`SVG content could not be obtained (${err})`);
-      warnings.push(`${svg.path}: ${err}`);
+    } catch (downloadError) {
+      const warningMsg = `SVG content of ${svg.path} could not be obtained`;
+      core.warning(`${warningMsg} (${downloadError})`);
+      warnings.push(warningMsg);
     }
   }
 
@@ -52,8 +52,7 @@ async function toBlobs(
   client: Octokit,
   files: FileData[],
 ): Promise<{ blobs: GitBlob[], warnings: string[] }> {
-  const blobs: GitBlob[] = [];
-  const warnings: string[] = [];
+  const blobs: GitBlob[] = [], warnings: string[] = [];
   for (const file of files) {
     core.debug(`encoding (updated) '${file.path}' to ${file.originalEncoding}`);
     const optimizedData: string = encode(file.content, file.originalEncoding);
@@ -68,9 +67,10 @@ async function toBlobs(
       );
 
       blobs.push(svgBlob);
-    } catch (err) {
-      core.warning(`Blob could not be created (${err})`);
-      warnings.push(`${file.path}: ${err}`);
+    } catch (uploadError) {
+      const warningMsg = `Blob for ${file.path} could not be created`;
+      core.warning(`${warningMsg} (${uploadError})`);
+      warnings.push(warningMsg);
     }
   }
 

--- a/src/events/helpers.ts
+++ b/src/events/helpers.ts
@@ -23,8 +23,9 @@ import {
 async function getSvgsContent(
   client: Octokit,
   svgList: GitFileInfo[],
-): Promise<FileData[]> {
+): Promise<{ svgs: FileData[], warnings: string[] }> {
   const svgs: FileData[] = [];
+  const warnings: string[] = [];
   for (const svg of svgList) {
     try {
       core.debug(`fetching file contents of '${svg.path}'`);
@@ -40,10 +41,11 @@ async function getSvgsContent(
       });
     } catch (err) {
       core.warning(`SVG content could not be obtained (${err})`);
+      warnings.push(`${svg.path}: ${err}`);
     }
   }
 
-  return svgs;
+  return { svgs, warnings };
 }
 
 async function toBlobs(
@@ -78,7 +80,7 @@ export function getCommitData(
   context: ContextData,
   optimizedSvgs: FileData[],
 ): CommitData {
-  const { fileCount, svgs, ignoredCount } = context;
+  const { fileCount, ignoredCount, svgs, warnings } = context;
   return {
     fileCount: fileCount,
     fileData: { optimized: optimizedSvgs, original: svgs },
@@ -86,6 +88,7 @@ export function getCommitData(
     optimizedCount: optimizedSvgs.length,
     skippedCount: svgs.length - optimizedSvgs.length,
     svgCount: svgs.length,
+    warnings: warnings,
   };
 }
 
@@ -141,8 +144,8 @@ export async function doFilterSvgsFromFiles(
   const ignoredCount = svgCount - notIgnoredSvgs.length;
   core.debug(`${ignoredCount} SVG(s) matching '${ignoreGlob}' will be ignored`);
 
-  const svgs: FileData[] = await getSvgsContent(client, notIgnoredSvgs);
-  return { fileCount, ignoredCount, svgs };
+  const { warnings, svgs } = await getSvgsContent(client, notIgnoredSvgs);
+  return { fileCount, ignoredCount, svgs, warnings };
 }
 
 export async function doOptimizeSvgs(

--- a/src/templating.ts
+++ b/src/templating.ts
@@ -13,6 +13,7 @@ const IGNORED_COUNT_EXP = /\{\{\s*ignoredCount\s*\}\}/;
 const OPTIMIZED_COUNT_EXP = /\{\{\s*optimizedCount\s*\}\}/;
 const SKIPPED_COUNT_EXP = /\{\{\s*skippedCount\s*\}\}/;
 const SVG_COUNT_EXP = /\{\{\s*svgCount\s*\}\}/;
+const WARNINGS_EXP = /\{\{\s*warnings\s*\}\}/;
 
 const FILE_COUNT_KEY = "fileCount";
 const FILE_DATA_KEY = "fileData";
@@ -20,6 +21,12 @@ const IGNORED_COUNT_KEY = "ignoredCount";
 const OPTIMIZED_COUNT_KEY = "optimizedCount";
 const SKIPPED_COUNT_KEY = "skippedCount";
 const SVG_COUNT_KEY = "svgCount";
+const WARNINGS_KEY = "warnings";
+
+const TITLE_EXCLUDE_KEYS: string[] = [
+  FILE_DATA_KEY,
+  WARNINGS_KEY,
+];
 
 const FILES_TABLE_HEADER =
   "| Filename | Before | After | Improvement |\n" +
@@ -95,6 +102,17 @@ const formatters = [
       return template.replace(SVG_COUNT_EXP, value.toString());
     },
   },
+  {
+    key: WARNINGS_KEY,
+    fn: (template: string, value: string[]): string => {
+      let warnings = "";
+      if (value.length > 0) {
+        warnings = value.reduce((acc, cur) => `${acc}\n- ${cur}`, "WARNINGS:");
+      }
+
+      return template.replace(WARNINGS_EXP, warnings);
+    },
+  },
 ];
 
 function formatAll(
@@ -125,7 +143,7 @@ export function formatCommitMessage(
   bodyTemplate: string,
   data: CommitData,
 ): string {
-  const title: string = formatAll(titleTemplate, data, [FILE_DATA_KEY]);
+  const title: string = formatAll(titleTemplate, data, TITLE_EXCLUDE_KEYS);
   const body: string = formatAll(bodyTemplate, data);
   return `${title}\n\n${body}`.trimRight();
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,6 +23,7 @@ export type CommitData = {
   readonly optimizedCount: number;
   readonly skippedCount: number;
   readonly svgCount: number;
+  readonly warnings: string[];
 }
 
 // Type representing the context w.r.t. files and SVGs the Action is running in.
@@ -30,6 +31,7 @@ export type ContextData = {
   readonly fileCount: number;
   readonly ignoredCount: number;
   readonly svgs: FileData[];
+  readonly warnings: string[];
 }
 
 // Type representing an Action configuration file.

--- a/test/pull-request.test.ts
+++ b/test/pull-request.test.ts
@@ -861,14 +861,14 @@ describe("Error scenarios", () => {
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
-    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("SVG content could not be obtained"));
+    expect(core.warning).toHaveBeenCalledWith(expect.stringMatching("SVG content .*could not be obtained"));
 
     expect(templating.formatCommitMessage).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.objectContaining({
         warnings: expect.arrayContaining([
-          expect.stringContaining(errorMessage),
+          expect.stringMatching("SVG content .*could not be obtained"),
         ]),
       }),
     );
@@ -882,14 +882,14 @@ describe("Error scenarios", () => {
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
-    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("Blob could not be created"));
+    expect(core.warning).toHaveBeenCalledWith(expect.stringMatching("Blob.* could not be created"));
 
     expect(templating.formatCommitMessage).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.objectContaining({
         warnings: expect.arrayContaining([
-          expect.stringContaining(errorMessage),
+          expect.stringMatching("Blob.* could not be created"),
         ]),
       }),
     );

--- a/test/pull-request.test.ts
+++ b/test/pull-request.test.ts
@@ -854,23 +854,45 @@ describe("Error scenarios", () => {
   });
 
   test("blob size is too large", async () => {
-    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error("Blob too large"); });
-    githubAPI.getPrNumber.mockReturnValueOnce(PR_NUMBER.ADD_SVG);
+    const errorMessage = "Blob too large";
+    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error(errorMessage); });
+    githubAPI.getPrNumber.mockReturnValueOnce(PR_NUMBER.MANY_CHANGES);
 
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
     expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("SVG content could not be obtained"));
+
+    expect(templating.formatCommitMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        warnings: expect.arrayContaining([
+          expect.stringContaining(errorMessage),
+        ]),
+      }),
+    );
   });
 
   test("optimized blob size is too large", async () => {
-    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error("Blob too large"); });
+    const errorMessage = "Blob too large";
+    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error(errorMessage); });
     githubAPI.getPrNumber.mockReturnValueOnce(PR_NUMBER.ADD_SVG);
 
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
     expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("Blob could not be created"));
+
+    expect(templating.formatCommitMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        warnings: expect.arrayContaining([
+          expect.stringContaining(errorMessage),
+        ]),
+      }),
+    );
   });
 
   test("missing head reference", async () => {

--- a/test/pull-request.test.ts
+++ b/test/pull-request.test.ts
@@ -854,8 +854,7 @@ describe("Error scenarios", () => {
   });
 
   test("blob size is too large", async () => {
-    const errorMessage = "Blob too large";
-    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error(errorMessage); });
+    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error("Blob too large"); });
     githubAPI.getPrNumber.mockReturnValueOnce(PR_NUMBER.MANY_CHANGES);
 
     await main(client, config, svgo);
@@ -875,8 +874,7 @@ describe("Error scenarios", () => {
   });
 
   test("optimized blob size is too large", async () => {
-    const errorMessage = "Blob too large";
-    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error(errorMessage); });
+    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error("Blob too large"); });
     githubAPI.getPrNumber.mockReturnValueOnce(PR_NUMBER.ADD_SVG);
 
     await main(client, config, svgo);

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -794,14 +794,14 @@ describe("Error scenarios", () => {
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
-    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("SVG content could not be obtained"));
+    expect(core.warning).toHaveBeenCalledWith(expect.stringMatching("SVG content .*could not be obtained"));
 
     expect(templating.formatCommitMessage).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.objectContaining({
         warnings: expect.arrayContaining([
-          expect.stringContaining(errorMessage),
+          expect.stringMatching("SVG content .*could not be obtained"),
         ]),
       }),
     );
@@ -815,14 +815,14 @@ describe("Error scenarios", () => {
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
-    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("Blob could not be created"));
+    expect(core.warning).toHaveBeenCalledWith(expect.stringMatching("Blob.* could not be created"));
 
     expect(templating.formatCommitMessage).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.objectContaining({
         warnings: expect.arrayContaining([
-          expect.stringContaining(errorMessage),
+          expect.stringMatching("Blob.* could not be created"),
         ]),
       }),
     );

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -787,9 +787,8 @@ describe("Error scenarios", () => {
   });
 
   test("blob size is too large", async () => {
-    const errorMessage = "Blob too large";
     github.context.payload.commits = [{ id: COMMIT_SHA.MANY_CHANGES }];
-    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error(errorMessage); });
+    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error("Blob too large"); });
 
     await main(client, config, svgo);
 
@@ -808,9 +807,8 @@ describe("Error scenarios", () => {
   });
 
   test("optimized blob size is too large", async () => {
-    const errorMessage = "Blob too large";
     github.context.payload.commits = [{ id: COMMIT_SHA.ADD_SVG }];
-    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error(errorMessage); });
+    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error("Blob too large"); });
 
     await main(client, config, svgo);
 

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -787,23 +787,45 @@ describe("Error scenarios", () => {
   });
 
   test("blob size is too large", async () => {
-    github.context.payload.commits = [{ id: COMMIT_SHA.ADD_SVG }];
-    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error("Blob too large"); });
+    const errorMessage = "Blob too large";
+    github.context.payload.commits = [{ id: COMMIT_SHA.MANY_CHANGES }];
+    githubAPI.getPrFile.mockImplementationOnce(() => { throw new Error(errorMessage); });
 
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
     expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("SVG content could not be obtained"));
+
+    expect(templating.formatCommitMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        warnings: expect.arrayContaining([
+          expect.stringContaining(errorMessage),
+        ]),
+      }),
+    );
   });
 
   test("optimized blob size is too large", async () => {
+    const errorMessage = "Blob too large";
     github.context.payload.commits = [{ id: COMMIT_SHA.ADD_SVG }];
-    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error("Blob too large"); });
+    githubAPI.createBlob.mockImplementationOnce(() => { throw new Error(errorMessage); });
 
     await main(client, config, svgo);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
     expect(core.warning).toHaveBeenCalledWith(expect.stringContaining("Blob could not be created"));
+
+    expect(templating.formatCommitMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        warnings: expect.arrayContaining([
+          expect.stringContaining(errorMessage),
+        ]),
+      }),
+    );
   });
 
 });


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Closes #241

This 1) adds the possibility to include a list of warnings in a commit message or Pull Request comment and 2) adds this to the default templates of both of this.

This is achieved by introducing a new templating variable called `{{warnings}}` (which is added to the default template for commit bodies and Pull Request comments). This templating variable will be replaced by an empty string if there are no warnings. If there are any warnings it will be replaced by something along the lines of

    WARNINGS
    - warning 1
    - warning 2
    - etc.

Implementation-wise this is achieved by introducing a new field on the `ContextData` and `CommitData` types that can be used to record any issues that should be reported as warnings.