### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,17 @@
+---
+name: Documentation
+about: Report problems with SVGO Action's documentation
+labels: docs
+---
+
+# Documentation
+
+## Description
+
+<!--
+Describe your problem with the documentation. For example, is something unclear,
+missing, or incorrect? Or is something else wrong?
+
+Also, if possible, provide an example text of how you would improve the
+existing documentation.
+--->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,16 +6,16 @@ labels: question
 
 # Question
 
-<!--
-Describe what your question is and, if possible, why you have this question.
-
-NOTE: if you are asking for a new feature, please submit a feature request.
---->
-
-## Background
-
 <!-- The version of the action you're using -->
 - **SVGO Action version**: <!-- e.g. v1.1.0 -->
 
 <!-- The context in which the action is running -->
 - **On**: <!-- choose from: 'push', 'pull_request' -->
+
+## Description
+
+<!--
+Describe what your question is and, if possible, why you have this question.
+
+NOTE: if you are asking for a new feature, please submit a feature request.
+--->

--- a/docs/options.md
+++ b/docs/options.md
@@ -338,7 +338,7 @@ svgo-options: my-svgo-options.yml
 [configuration file]: https://github.com/ericcornelissen/svgo-action#in-another-configuration-file
 [conventional commit]: https://www.conventionalcommits.org/
 [glob]: https://en.wikipedia.org/wiki/Glob_(programming)
-[open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new
+[open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
 [svgo]: https://github.com/svg/svgo
 [the templating documentation]: /docs/templating.md
 [yaml]: https://yaml.org/


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- ~~I added my change to the Changelog.~~

### Description

Continuing the work in #254, this adds a new GitHub issues template for issues regarding the documentation and updates the link in the documentation to open an issue to use this template.
