### PR TITLE
Fix bug making commits impossible

### DIFF
--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -14,7 +14,7 @@ const repo = github.context.repo.repo;
 
 async function getCommitAt(client: Octokit, ref: string): Promise<GitCommit> {
   const { data: refData } = await client.git.getRef({ owner, repo, ref });
-  const { data: commit } = await client.git.getCommit({ owner, ref,
+  const { data: commit } = await client.git.getCommit({ owner, repo,
     commit_sha: refData.object.sha,
   });
 

--- a/test/github-api.test.ts
+++ b/test/github-api.test.ts
@@ -272,6 +272,39 @@ describe("::getCommitMessage", () => {
 
 });
 
+describe("::getFile", () => {
+
+  const filePaths: string[] = Object.keys(files).slice(0, 4);
+
+  test.each(filePaths)("get an existing file (%s)", async (filePath) => {
+    const fileData: GitFileData = await getFile(client, filePath);
+    expect(fileData).toBeDefined();
+  });
+
+  test.each(filePaths)("'path' is defined for existing file (%s)", async (filePath) => {
+    const fileData: GitFileData = await getFile(client, filePath);
+    expect(fileData.path).toBeDefined();
+  });
+
+  test.each(filePaths)("'content' is defined for existing file (%s)", async (filePath) => {
+    const fileData: GitFileData = await getFile(client, filePath);
+    expect(fileData.content).toBeDefined();
+  });
+
+  test.each(filePaths)("'encoding' is defined for existing file (%s)", async (filePath) => {
+    const fileData: GitFileData = await getFile(client, filePath);
+    expect(fileData.encoding).toBeDefined();
+  });
+
+  test("file is not found", async () => {
+    github.GitHubInstance.repos.getContent.mockRejectedValueOnce(new Error("Not found"));
+
+    const promise = getFile(client, "foobar");
+    await expect(promise).rejects.toBeDefined();
+  });
+
+});
+
 describe("::getPrComments", () => {
 
   test("no comments", async () => {
@@ -302,39 +335,6 @@ describe("::getPrComments", () => {
   test("103 comments", async () => {
     const result = await getPrComments(client, github.PR_NUMBER.ONE_HUNDRED_AND_THREE_COMMENTS);
     expect(result).toHaveLength(103);
-  });
-
-});
-
-describe("::getFile", () => {
-
-  const filePaths: string[] = Object.keys(files).slice(0, 4);
-
-  test.each(filePaths)("get an existing file (%s)", async (filePath) => {
-    const fileData: GitFileData = await getFile(client, filePath);
-    expect(fileData).toBeDefined();
-  });
-
-  test.each(filePaths)("'path' is defined for existing file (%s)", async (filePath) => {
-    const fileData: GitFileData = await getFile(client, filePath);
-    expect(fileData.path).toBeDefined();
-  });
-
-  test.each(filePaths)("'content' is defined for existing file (%s)", async (filePath) => {
-    const fileData: GitFileData = await getFile(client, filePath);
-    expect(fileData.content).toBeDefined();
-  });
-
-  test.each(filePaths)("'encoding' is defined for existing file (%s)", async (filePath) => {
-    const fileData: GitFileData = await getFile(client, filePath);
-    expect(fileData.encoding).toBeDefined();
-  });
-
-  test("file is not found", async () => {
-    github.GitHubInstance.repos.getContent.mockRejectedValueOnce(new Error("Not found"));
-
-    const promise = getFile(client, "foobar");
-    await expect(promise).rejects.toBeDefined();
   });
 
 });

--- a/test/mocks/@actions/github.mock.ts
+++ b/test/mocks/@actions/github.mock.ts
@@ -9,6 +9,17 @@ import * as prPayloads from "../../fixtures/pull-request-payloads.json";
 import { EVENT_PULL_REQUEST } from "../../../src/constants";
 
 
+function anyAreUndefined(values: unknown[]): boolean {
+  for (const value of values) {
+    if (value === undefined) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
 export enum PR_NUMBER {
   NO_CHANGES,
   MANY_CHANGES,
@@ -71,6 +82,7 @@ export const context: {
     owner: string,
     repo: string,
   },
+  sha: string,
 } = {
   eventName: EVENT_PULL_REQUEST,
   payload: {
@@ -90,12 +102,17 @@ export const context: {
     owner: "pickachu",
     repo: "svgo-action",
   },
+  sha: "60e82798538f1853144300adaaa00650c9a6ab4d",
 };
 
 export const GitHubInstance = {
   git: {
     createBlob: jest.fn()
-      .mockImplementation(async () => {
+      .mockImplementation(async ({ owner, repo, content, encoding }) => {
+        if (anyAreUndefined([owner, repo, content, encoding])) {
+          throw Error("Missing parameter(s)");
+        }
+
         return {
           data: {
             sha: "b23aa12490660754aff4920ff23909dc324cc1dd",
@@ -104,7 +121,11 @@ export const GitHubInstance = {
       })
       .mockName("GitHub.git.createBlob"),
     createCommit: jest.fn()
-      .mockImplementation(async () => {
+      .mockImplementation(async ({ owner, repo, message, tree, parents }) => {
+        if (anyAreUndefined([owner, repo, message, tree, parents])) {
+          throw Error("Missing parameter(s)");
+        }
+
         return {
           data: {
             sha: "8482592589d34923489284f3940776702123aaf3",
@@ -113,7 +134,11 @@ export const GitHubInstance = {
       })
       .mockName("GitHub.git.createCommit"),
     createTree: jest.fn()
-      .mockImplementation(async () => {
+      .mockImplementation(async ({ owner, repo, base_tree, tree }) => {
+        if (anyAreUndefined([owner, repo, base_tree, tree])) {
+          throw Error("Missing parameter(s)");
+        }
+
         return {
           data: {
             sha: "ccaf32432ff32754aff4920ff23909dc33788965",
@@ -122,7 +147,11 @@ export const GitHubInstance = {
       })
       .mockName("GitHub.git.createTree"),
     getCommit: jest.fn()
-      .mockImplementation(async () => {
+      .mockImplementation(async ({ owner, repo, commit_sha }) => {
+        if (anyAreUndefined([owner, repo, commit_sha])) {
+          throw Error("Missing parameter(s)");
+        }
+
         return {
           data: {
             message: "This is a commit message",
@@ -134,8 +163,14 @@ export const GitHubInstance = {
       })
       .mockName("GitHub.git.getCommit"),
     getRef: jest.fn()
-      .mockImplementation(async ({ ref }) => {
-        if (ref.endsWith("undefined")) throw new Error("Invalid ref");
+      .mockImplementation(async ({ owner, repo, ref }) => {
+        if (anyAreUndefined([owner, repo, ref])) {
+          throw Error("Missing parameter(s)");
+        }
+
+        if (ref.endsWith("undefined")) {
+          throw new Error("Invalid ref");
+        }
 
         return {
           data: {
@@ -147,7 +182,11 @@ export const GitHubInstance = {
       })
       .mockName("GitHub.git.getRef"),
     updateRef: jest.fn()
-      .mockImplementation(async () => {
+      .mockImplementation(async ({ owner, repo, ref, sha }) => {
+        if (anyAreUndefined([owner, repo, ref, sha])) {
+          throw Error("Missing parameter(s)");
+        }
+
         return {
           data: {
             object: {
@@ -160,13 +199,24 @@ export const GitHubInstance = {
   },
   issues: {
     createComment: jest.fn()
+      .mockImplementation(async ({ owner, repo, issue_number, body }) => {
+        if (anyAreUndefined([owner, repo, issue_number, body])) {
+          throw Error("Missing parameter(s)");
+        }
+      })
       .mockName("GitHub.issues.createComment"),
     listComments: jest.fn()
       .mockImplementation(async ({
+        owner,
+        repo,
         issue_number: prNumber,
         per_page: perPage,
         page,
       }) => {
+        if (anyAreUndefined([owner, repo, prNumber, perPage, page])) {
+          throw Error("Missing parameter(s)");
+        }
+
         const generateComments = function(length) {
           return Array.from({ length }).map((_, i) => ({ body: `${i}` }));
         };
@@ -203,7 +253,11 @@ export const GitHubInstance = {
   },
   pulls: {
     get: jest.fn()
-      .mockImplementation(async ({ pull_number: prNumber }) => {
+      .mockImplementation(async ({ owner, repo, pull_number: prNumber }) => {
+        if (anyAreUndefined([owner, repo, prNumber])) {
+          throw Error("Missing parameter(s)");
+        }
+
         switch (prNumber) {
           case PR_NUMBER.NO_COMMENTS:
             return { data: { comments: 0 } };
@@ -223,7 +277,11 @@ export const GitHubInstance = {
       })
       .mockName("GitHub.pulls.get"),
     listFiles: jest.fn()
-      .mockImplementation(async ({ pull_number: prNumber }) => {
+      .mockImplementation(async ({ owner, repo, pull_number: prNumber }) => {
+        if (anyAreUndefined([owner, repo, prNumber])) {
+          throw Error("Missing parameter(s)");
+        }
+
         switch (prNumber) {
           case PR_NUMBER.NO_CHANGES:
             return { data: [ ] };
@@ -265,12 +323,20 @@ export const GitHubInstance = {
   },
   repos: {
     getCommit: jest.fn()
-      .mockImplementation(async ({ ref }) => {
+      .mockImplementation(async ({ owner, repo, ref }) => {
+        if (anyAreUndefined([owner, repo, ref])) {
+          throw Error("Missing parameter(s)");
+        }
+
         return { data: commitPayloads[ref] };
       })
       .mockName("GitHub.repos.getCommit"),
     getContent: jest.fn()
-      .mockImplementation(async ({ path }) => {
+      .mockImplementation(async ({ owner, repo, path, ref }) => {
+        if (anyAreUndefined([owner, repo, path, ref])) {
+          throw Error("Missing parameter(s)");
+        }
+
         return { data: contentPayloads[path] };
       })
       .mockName("GitHub.repos.getContent"),

--- a/test/mocks/github-api.mock.ts
+++ b/test/mocks/github-api.mock.ts
@@ -55,13 +55,13 @@ export const getCommitMessage = jest.fn()
   .mockResolvedValue("This is a commit message")
   .mockName("github-api.getCommitMessage");
 
-export const getPrComments = jest.fn()
-  .mockResolvedValue([])
-  .mockName("github-api.getPrComment");
-
 export const getFile = jest.fn()
   .mockImplementation(async (_, path) => await getContent(path))
   .mockName("github-api.getFile");
+
+export const getPrComments = jest.fn()
+  .mockResolvedValue([])
+  .mockName("github-api.getPrComment");
 
 export const getPrFiles = jest.fn()
   .mockImplementation(async (_, prNumber) => {

--- a/test/mocks/github-api.mock.ts
+++ b/test/mocks/github-api.mock.ts
@@ -13,7 +13,13 @@ const token = core.getInput(INPUT_NAME_REPO_TOKEN, { required: true });
 const client = github.getOctokit(token);
 
 async function getContent(path: string): Promise<GitFileData> {
-  const { data } = await client.repos.getContent({ path });
+  const { data } = await client.repos.getContent({
+    owner: "mew",
+    repo: "svg-action",
+    path,
+    ref: "heads/ref",
+  });
+
   return {
     path: data.path,
     content: data.content,
@@ -43,7 +49,12 @@ export const createComment = jest.fn()
 
 export const getCommitFiles = jest.fn()
   .mockImplementation(async (_, sha) => {
-    const { data } = await client.repos.getCommit({ ref: sha });
+    const { data } = await client.repos.getCommit({
+      owner: "mew",
+      repo: "svg-action",
+      ref: sha,
+    });
+
     return data.files.map((details) => ({
       path: details.filename,
       status: details.status,
@@ -66,6 +77,8 @@ export const getPrComments = jest.fn()
 export const getPrFiles = jest.fn()
   .mockImplementation(async (_, prNumber) => {
     const { data } = await client.pulls.listFiles({
+      owner: "mew",
+      repo: "svg-action",
       pull_number: prNumber,
     });
 


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- ~~I updated the documentation according to my changes.~~
- ~~I added my change to the Changelog.~~

### Description

This fixes a bug introduced in #263 / d831dd5883222587109017a94a26e1b2ddb122e8 during refactoring. Specifically, one of the argument into `Octokit.git.getCommit` was replaced by an argument that is not used by the function. Unfortunately, TypeScript wasn't able to catch this bug. The bug has been fixed and the mock of [`at-actions/gitbub`](https://www.npmjs.com/package/@actions/github) has been updated to throw an error if any of the required parameters are missing, ensuring a bug like this will be caught in the feature.

In addition, the `github-api.test.ts` and `github-api.mock.ts` files have been reordered to match `github-api.ts`.

THE BUG HAS NOT AFFECTED ANY RELEASED VERSIONS OF THIS SOFTWARE
