### PR TITLE
Remove pjs for package.json validation

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -29,10 +29,6 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 12.x
-    - name: Install package-json-validator
-      run: npm install -g package-json-validator
-    - name: Validate package.json
-      run: pjv -w -r --spec npm
     - name: Validate package-lock.json
       run: |
         # `npm install` changes the lockfile metadata if it doesn't match

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "lint:ws": "editorconfig-checker",
     "postinstall": "is-ci || husky install script/hooks",
     "test": "jest",
-    "test:coverage": "jest --coverage",
     "validate-config": "npx ts-node ./script/config-validation/cli.ts"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:ws": "editorconfig-checker",
     "postinstall": "is-ci || husky install script/hooks",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "validate-config": "npx ts-node ./script/config-validation/cli.ts"
   },
   "repository": {


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [n/a] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

As per [this build failure](https://github.com/ericcornelissen/svgo-action/pull/330/checks?check_run_id=1943467171#step:5:13), PJV is no longer sufficient for verifying the validity of `package.json` for this project.