### PR TITLE
Reconfigure Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,16 @@
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],
       automerge: true,
     },
+    {
+      // Configure SVGO v1: don't upgrade to v2.x.x
+      matchPackageNames: ["svgo-v1"],
+      allowedVersions: "<2.0.0"
+    },
+    {
+      // Configure SVGO v2: don't upgrade to v3.x.x
+      matchPackageNames: ["svgo-v2"],
+      allowedVersions: "<3.0.0"
+    }
   ],
 
   lockFileMaintenance: {


### PR DESCRIPTION

<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [n/a] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

Attempt to prevent RenovateBot from updating svgo-v1 to v2.x.x and svgo-v2 to v3.x.x (if it is ever released).
