### PR TITLE
Upgrade SVGO v2 to the latest v2.x.x. release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v2 to `v2.2.1`. ([#344])
 
 ## [1.3.1] - 2021-03-02
 
@@ -210,4 +210,5 @@ Versioning].
 [#335]: https://github.com/ericcornelissen/svgo-action/pull/335
 [#337]: https://github.com/ericcornelissen/svgo-action/pull/337
 [#339]: https://github.com/ericcornelissen/svgo-action/pull/339
+[#344]: https://github.com/ericcornelissen/svgo-action/pull/344
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -8516,15 +8516,14 @@
       }
     },
     "svgo-v2": {
-      "version": "npm:svgo@2.2.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.2.0.tgz",
-      "integrity": "sha512-78w27VB+Vvca8TNRZrpbN70OTaVXgyQKm/rBiEqFPZmEJkn6i3PqEgIniPqPY6H2kFevakixAfBaQlwuStZuBA==",
+      "version": "npm:svgo@2.2.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.2.1.tgz",
+      "integrity": "sha512-WrKhe5CMm/O5gchTQKGogKYXGbOC0JBZnHqvaCTEbsMuq4prxQHB/AZgif8WwD4+9Nim4EECObmyjvkdC43iNg==",
       "requires": {
         "@trysound/sax": "0.1.1",
         "chalk": "^4.1.0",
         "commander": "^7.1.0",
         "css-select": "^3.1.2",
-        "css-select-base-adapter": "^0.1.1",
         "css-tree": "^1.1.2",
         "csso": "^4.2.0",
         "stable": "^0.1.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6977,9 +6977,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-          "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -7057,9 +7057,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-          "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "js-yaml": "4.0.0",
     "minimatch": "3.0.4",
     "svgo-v1": "npm:svgo@1.3.2",
-    "svgo-v2": "npm:svgo@2.2.0"
+    "svgo-v2": "npm:svgo@2.2.1"
   },
   "devDependencies": {
     "@commitlint/cli": "12.0.1",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [n/a] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Update the [SVGO v2 dependency](https://github.com/ericcornelissen/svgo-action/blob/13e686ebe87ffd4d03a4aaa84c01c580cd0a8dc0/package.json#L49) to the [latest](https://github.com/svg/svgo/releases) (current [v2.2.1](https://github.com/svg/svgo/releases/tag/v2.2.1))
