### PR TITLE
Improve v2 docs on manual events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 ## [Unreleased]
 
 - Re-add the ability to leave comments on Pull Requests. ([#343])
+- Fix documentation on manually triggered events in v2. ([#346])
 
 ## [2.0.0-alpha.1] - 2021-03-02
 
@@ -225,4 +226,5 @@ Versioning].
 [#339]: https://github.com/ericcornelissen/svgo-action/pull/339
 [#343]: https://github.com/ericcornelissen/svgo-action/pull/343
 [#344]: https://github.com/ericcornelissen/svgo-action/pull/344
+[#346]: https://github.com/ericcornelissen/svgo-action/pull/346
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    # Enable the following if you want to select a branch for scheduled runs.
+    # Enable the following to select a branch for scheduled or triggered runs.
     # with:
     #   path: main
     - uses: ericcornelissen/svgo-action@next

--- a/docs/events.md
+++ b/docs/events.md
@@ -5,9 +5,9 @@ Action supports.
 
 - [`on: pull_request`](#on-pull_request)
 - [`on: push`](#on-push)
-- [`on: repository_dispatch`](#manual-events)
+- [`on: repository_dispatch`](#manually-triggered-events)
 - [`on: schedule`](#on-schedule)
-- [`on: workflow_dispatch`](#manual-events)
+- [`on: workflow_dispatch`](#manually-triggered-events)
 
 Please [open an issue] if you found a mistake or if you have suggestions for how
 to improve the documentation.
@@ -90,7 +90,7 @@ The following [options] have an effect in the `schedule` context.
 | `svgo-options`         | :heavy_check_mark: |
 | `svgo-version`         | :heavy_check_mark: |
 
-## Manual events
+## Manually triggered events
 
 > Find out more in the GitHub Actions documentation on [`repository_dispatch`
 > events] and [`workflow_dispatch` events].
@@ -108,10 +108,7 @@ The following [options] have an effect in the `repository_dispatch` and
 
 | Name                   | Supported          |
 | ---------------------- | ------------------ |
-| `branch`               | :heavy_check_mark: |
 | `comment`              | :x:                |
-| `commit`               | :heavy_check_mark: |
-| `conventional-commits` | :heavy_check_mark: |
 | `dry-run`              | :heavy_check_mark: |
 | `ignore`               | :heavy_check_mark: |
 | `svgo-version`         | :heavy_check_mark: |


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Fix some minor mistakes in the documentation w.r.t. manually triggered events (i.e. `repository_dispatch` and `workflow_dispatch`)
