### PR TITLE
Add warning about running Action from forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add warning about running the Action for Pull Requests from forks. ([#355])
 
 ## [1.3.3] - 2021-04-02
 
@@ -220,4 +220,5 @@ Versioning].
 [#339]: https://github.com/ericcornelissen/svgo-action/pull/339
 [#344]: https://github.com/ericcornelissen/svgo-action/pull/344
 [#352]: https://github.com/ericcornelissen/svgo-action/pull/352
+[#355]: https://github.com/ericcornelissen/svgo-action/pull/355
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ jobs:
 _Note: This grants access to the `GITHUB_TOKEN` so the Action can make calls to
 GitHub's rest API_
 
+> :warning: This Action does not work for Pull Requests from forks. This is
+> because GitHub Actions do not have permission to alter forked repositories.
+
 ### Configure the Action
 
 There are a couple of ways for you to configure the Action. You can configure it


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

As suggested in #354, this adds a disclaimer to the README that the Action does not work for Pull Requests from forks.
