### PR TITLE
Use action/core's `getBooleanInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 ## [Unreleased]
 
 - Add warning about running the Action for Pull Requests from forks. ([#355])
+- Allow more values for boolean options. ([#371])
 
 ## [1.3.3] - 2021-04-02
 
@@ -221,4 +222,5 @@ Versioning].
 [#344]: https://github.com/ericcornelissen/svgo-action/pull/344
 [#352]: https://github.com/ericcornelissen/svgo-action/pull/352
 [#355]: https://github.com/ericcornelissen/svgo-action/pull/355
+[#371]: https://github.com/ericcornelissen/svgo-action/pull/371
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -168,12 +168,15 @@ export class ActionConfig {
 
   private static normalizeBoolOption(
     inputs: Inputs,
-    configValue: boolean | undefined,
+    configValue: boolean | string | undefined,
     inputName: string,
     defaultValue: boolean,
   ): boolean {
-    const value = (configValue !== undefined) ?
-      configValue : inputs.getInput(inputName, NOT_REQUIRED);
+    let value;
+    try {
+      value = (configValue !== undefined) ?
+        configValue : inputs.getBooleanInput(inputName, NOT_REQUIRED);
+    } catch (_) { /* Fall through and return `defaultValue` */ }
 
     if (typeof value === BOOLEAN) {
       return value as boolean;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -93,6 +93,7 @@ export type GitObjectInfo = {
 
 // Type representing an object from which the Action inputs can be obtained.
 export type Inputs = {
+  getBooleanInput(name: string, options: InputOptions): boolean
   getInput(name: string, options: InputOptions): string;
 }
 

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -21,6 +21,22 @@ import { ActionConfig } from "../src/inputs";
 import { RawActionConfig } from "../src/types";
 
 
+function mockCoreGetBooleanInput(
+  key: string,
+  value: boolean | string,
+  throws?: boolean,
+): void {
+  if (throws) {
+    when(core.getBooleanInput)
+      .calledWith(key, expect.any(Object))
+      .mockImplementation(() => { throw new TypeError("Invalid string"); });
+  } else {
+    when(core.getBooleanInput)
+      .calledWith(key, expect.any(Object))
+      .mockReturnValue(value);
+  }
+}
+
 function mockCoreGetInput(key: string, value: string): void {
   when(core.getInput)
     .calledWith(key, expect.any(Object))
@@ -166,7 +182,7 @@ describe("ActionConfig", () => {
     const CONVENTIONAL_COMMIT_EXP = /.+:\s.+/;
 
     test("commit is not defined in the config object", () => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, false);
 
       const instance: ActionConfig = new ActionConfig(core, { });
       expect(instance.commitTitle).toEqual(DEFAULT_COMMIT_TITLE);
@@ -182,7 +198,7 @@ describe("ActionConfig", () => {
       "This is templated commit message title {{optimizedCount}}",
       "If you see a rat the size of a car, you're playing the wrong game",
     ])("commit message title is defined in the config object", (title) => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, false);
 
       const instance: ActionConfig = new ActionConfig(core, { commit: { title } });
       expect(instance.commitTitle).toEqual(title);
@@ -195,7 +211,7 @@ describe("ActionConfig", () => {
     });
 
     test("conventional-commits is enabled and no commit message title is specified", () => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, true);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.commitTitle).toBeDefined();
@@ -204,7 +220,7 @@ describe("ActionConfig", () => {
     });
 
     test("conventional-commits is enabled and a commit message title is specified", () => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, true);
 
       const instance: ActionConfig = new ActionConfig(core, { commit: { title: "deadbeef" } });
       expect(instance.commitTitle).toBeDefined();
@@ -213,7 +229,7 @@ describe("ActionConfig", () => {
     });
 
     test("conventional-commits is disabled and no commit message title is specified", () => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, false);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.commitTitle).toBeDefined();
@@ -221,14 +237,14 @@ describe("ActionConfig", () => {
     });
 
     test("conventional-commits is disabled and a commit message title is specified", () => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, false);
 
       const instance: ActionConfig = new ActionConfig(core, { commit: { title: "Do the thing" } });
       expect(instance.commitTitle).toEqual("Do the thing");
     });
 
     test.each(nonBooleanStrings)("conventional-commits is '%s'", (value) => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, value);
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, value, true);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.commitTitle).toMatch(CONVENTIONAL_COMMIT_EXP);
@@ -273,7 +289,7 @@ describe("ActionConfig", () => {
     });
 
     test("conventional-commits enabled and commit.conventional disabled", () => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, true);
 
       const instance: ActionConfig = new ActionConfig(core, { commit: { conventional: false } });
       expect(instance.commitTitle).toBeDefined();
@@ -281,7 +297,7 @@ describe("ActionConfig", () => {
     });
 
     test("conventional-commits disabled and commit.conventional enabled", () => {
-      mockCoreGetInput(INPUT_NAME_CONVENTIONAL_COMMITS, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_CONVENTIONAL_COMMITS, false);
 
       const instance: ActionConfig = new ActionConfig(core, { commit: { conventional: true } });
       expect(instance.commitTitle).toBeDefined();
@@ -294,33 +310,33 @@ describe("ActionConfig", () => {
   describe(".enableComments", () => {
 
     test("comment is not set at all", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
-      const defaultValue = "false";
-      mockCoreGetInput(INPUT_NAME_COMMENT, defaultValue);
+      const defaultValue = false;
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, defaultValue);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.enableComments).toBe(false);
     });
 
     test("comment is `'false'` in the Workflow file", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
-      mockCoreGetInput(INPUT_NAME_COMMENT, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, false);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.enableComments).toBe(false);
     });
 
     test("comment is `'true'` in the Workflow file", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
-      mockCoreGetInput(INPUT_NAME_COMMENT, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, true);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.enableComments).toBe(true);
     });
 
     test.each(nonBooleanStrings)("comment is `'%s'` in the Workflow file", (value) => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
       mockCoreGetInput(INPUT_NAME_COMMENT, value);
 
       const instance: ActionConfig = new ActionConfig(core);
@@ -328,7 +344,7 @@ describe("ActionConfig", () => {
     });
 
     test("comment is `false` in the config object", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const rawConfig = yaml.load("comment: false") as RawActionConfig;
       mockCoreGetInput(INPUT_NAME_COMMENT, "true");
@@ -338,48 +354,48 @@ describe("ActionConfig", () => {
     });
 
     test("comment is `true` in the config object", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const rawConfig = yaml.load("comment: true") as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_COMMENT, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, false);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.enableComments).toBe(true);
     });
 
     test("comment is `'false'` in the config object", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const rawConfig = yaml.load("comment: 'false'") as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_COMMENT, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, true);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.enableComments).toBe(false);
     });
 
     test("comment is `'true'` in the config object", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const rawConfig = yaml.load("comment: 'true'") as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_COMMENT, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, false);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.enableComments).toBe(true);
     });
 
     test.each(nonBooleanStrings)("comment is `'%s'` in the config object", (value) => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const rawConfig = yaml.load(`comment: '${value}'`) as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_COMMENT, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, false);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.enableComments).toBe(true);
     });
 
-    test.each(["true", "false"])("dry-run is true and comment is `%s`", (value) => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "true");
-      mockCoreGetInput(INPUT_NAME_COMMENT, value);
+    test.each([true, false])("dry-run is true and comment is `%s`", (value) => {
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, true);
+      mockCoreGetBooleanInput(INPUT_NAME_COMMENT, value);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.enableComments).toBe(false);
@@ -390,29 +406,29 @@ describe("ActionConfig", () => {
   describe(".isDryRun", () => {
 
     test("dry-run is not set at all", () => {
-      const defaultValue = "false";
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, defaultValue);
+      const defaultValue = false;
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, defaultValue);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.isDryRun).toBe(false);
     });
 
     test("dry-run is `'false'` in the workflow file", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.isDryRun).toBe(false);
     });
 
     test("dry-run is `'true'` in the workflow file", () => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, true);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.isDryRun).toBe(true);
     });
 
     test.each(nonBooleanStrings)("dry-run is `'%s'` in the workflow file", (value) => {
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, value);
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, value, true);
 
       const instance: ActionConfig = new ActionConfig(core);
       expect(instance.isDryRun).toBe(true);
@@ -420,7 +436,7 @@ describe("ActionConfig", () => {
 
     test("dry-run is `false` in the config object", () => {
       const rawConfig = yaml.load("dry-run: false") as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, true);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.isDryRun).toBe(false);
@@ -428,7 +444,7 @@ describe("ActionConfig", () => {
 
     test("dry-run is `true` in the config object", () => {
       const rawConfig = yaml.load("dry-run: true") as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.isDryRun).toBe(true);
@@ -436,7 +452,7 @@ describe("ActionConfig", () => {
 
     test("dry-run is `'false'` in the config object", () => {
       const rawConfig = yaml.load("dry-run: 'false'") as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "true");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, true);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.isDryRun).toBe(false);
@@ -444,7 +460,7 @@ describe("ActionConfig", () => {
 
     test("dry-run is `'true'` in the config object", () => {
       const rawConfig = yaml.load("dry-run: 'true'") as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.isDryRun).toBe(true);
@@ -452,7 +468,7 @@ describe("ActionConfig", () => {
 
     test.each(nonBooleanStrings)("dry-run is `'%s'` in the config object", (value) => {
       const rawConfig = yaml.load(`dry-run: '${value}'`) as RawActionConfig;
-      mockCoreGetInput(INPUT_NAME_DRY_RUN, "false");
+      mockCoreGetBooleanInput(INPUT_NAME_DRY_RUN, false);
 
       const instance: ActionConfig = new ActionConfig(core, rawConfig);
       expect(instance.isDryRun).toBe(true);

--- a/test/mocks/@actions/core.mock.ts
+++ b/test/mocks/@actions/core.mock.ts
@@ -10,14 +10,21 @@ export const debug = jest.fn().mockName("core.debug");
 
 export const error = jest.fn().mockName("core.error");
 
+export const getBooleanInput = jest.fn()
+  .mockImplementation((key, _) => {
+    if (key === INPUT_NAME_CONVENTIONAL_COMMITS) {
+      return false;
+    } else if (key === INPUT_NAME_DRY_RUN) {
+      return false;
+    }
+
+    return false;
+  });
+
 export const getInput = jest.fn()
   .mockImplementation((key, _) => {
     if (key === INPUT_NAME_CONFIG_PATH) {
       return "./config.yml";
-    } else if (key === INPUT_NAME_CONVENTIONAL_COMMITS) {
-      return "false";
-    } else if (key === INPUT_NAME_DRY_RUN) {
-      return "false";
     } else if (key === INPUT_NAME_REPO_TOKEN) {
       return "TOKEN";
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

This updates [the `ActionConfig` class](https://github.com/ericcornelissen/svgo-action/blob/e0ca49560973c782fc7440e0dace8d287ef20dc0/src/inputs.ts#L28) to use the in [`actions/core` v1.3.0](https://github.com/actions/toolkit/blob/db2162799533caab4cc6e54ebc102be1838822b3/packages/core/RELEASES.md#130) introduced `getBooleanInput` function. This function is a bit more forgiving with respect to what strings it considers to be booleans, extending the list from `"false"` and `"true"` to `"true"`, `"True"`, `"TRUE`", `"false`", `"False`", and `"FALSE"`.