### PR TITLE
Only optimize SVGs in the pushed commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased, v2]
 
-- _No changes yet_
+- Only optimize SVGs in the pushed commits in that context. ([#382])
 
 ## [2.0.0-alpha.4] - 2021-07-21
 
@@ -269,4 +269,5 @@ Versioning].
 [#376]: https://github.com/ericcornelissen/svgo-action/pull/376
 [#378]: https://github.com/ericcornelissen/svgo-action/pull/378
 [#380]: https://github.com/ericcornelissen/svgo-action/pull/380
+[#382]: https://github.com/ericcornelissen/svgo-action/pull/382
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/src/clients/types.d.ts
+++ b/src/clients/types.d.ts
@@ -1,6 +1,30 @@
 import type { error } from "../types";
 
+interface CommitsGetCommitParams {
+  readonly owner: string;
+  readonly repo: string;
+  readonly ref: string;
+}
+
+interface CommitsGetCommitResponse {
+  readonly files: GitFileInfo[];
+}
+
+type CommitsListFilesParams = CommitsGetCommitParams;
+
+type CommitsListFilesResponse = GitFileInfo[];
+
+interface GitFileInfo {
+  readonly filename: string;
+  readonly status: string;
+}
+
 interface GitHubClient {
+  readonly commits: {
+    listFiles(
+      params: CommitsListFilesParams,
+    ): Promise<[CommitsListFilesResponse, error]>;
+  }
   readonly pulls: {
     listFiles(
       params: PullsListFilesParams,
@@ -36,10 +60,26 @@ interface Octokit {
         data: { filename: string; status: string; }[]
       }>;
     };
+    readonly repos: {
+      getCommit(params: {
+        owner: string;
+        repo: string;
+        ref: string;
+      }): Promise<{
+        data: {
+          files: { filename: string; status: string; }[];
+        }
+      }>;
+    };
   };
 }
 
 export type {
+  CommitsGetCommitParams,
+  CommitsGetCommitResponse,
+  CommitsListFilesParams,
+  CommitsListFilesResponse,
+  GitFileInfo,
   GitHubClient,
   Octokit,
   PullsListFilesParams,

--- a/src/file-systems/index.ts
+++ b/src/file-systems/index.ts
@@ -2,12 +2,14 @@ import type { GitHubClient } from "../clients";
 import type { error, Context } from "../types";
 import type { FileInfo, FileSystem } from "./types";
 import type { PrContext } from "./pr";
+import type { PushContext } from "./push";
 
 import * as path from "path";
 
 import { EVENTS } from "../constants";
 import { BaseFileSystem } from "./base";
 import { createPrFileSystemBuilder } from "./pr";
+import { createPushFileSystemBuilder } from "./push";
 
 interface Params {
   readonly client: GitHubClient;
@@ -15,6 +17,7 @@ interface Params {
 }
 
 const newPullRequest = createPrFileSystemBuilder({ fs: BaseFileSystem, path });
+const newPush = createPushFileSystemBuilder({ fs: BaseFileSystem, path });
 const newStandard = (): FileSystem => BaseFileSystem;
 
 async function New({ client, context }: Params): Promise<[FileSystem, error]> {
@@ -23,6 +26,9 @@ async function New({ client, context }: Params): Promise<[FileSystem, error]> {
   switch (context.eventName) {
     case EVENTS.pullRequest:
       [fileSystem, err] = await newPullRequest(client, context as PrContext);
+      break;
+    case EVENTS.push:
+      [fileSystem, err] = await newPush(client, context as PushContext);
       break;
     default:
       fileSystem = newStandard();

--- a/src/file-systems/push.ts
+++ b/src/file-systems/push.ts
@@ -1,0 +1,91 @@
+import type { error } from "../types";
+import type { GitHubClient } from "../clients";
+import type { FileInfo, FileSystem, ListFilesFn } from "./types";
+
+import errors from "../errors";
+
+interface Context {
+  readonly payload: {
+    readonly commits: {
+      id: string;
+    }[];
+  };
+  readonly repo: {
+    readonly owner: string;
+    readonly repo: string;
+  };
+}
+
+async function getPushFiles(
+  client: GitHubClient,
+  context: Context,
+): Promise<[string[], error]> {
+  const result: string[] = [];
+  let err: error = null;
+
+  for (const commit of context.payload.commits) {
+    const [data, err0] = await client.commits.listFiles({
+      ...context.repo,
+      ref: commit.id,
+    });
+
+    if (err0 !== null) {
+      err = errors.New(`Could not get commit '${commit.id}' (${err0})`);
+      break;
+    }
+
+    const files = data
+      .filter((entry) => entry.status !== "removed")
+      .map((entry) => entry.filename);
+    result.push(...files);
+  }
+
+  return [result, err];
+}
+
+function createListFiles(
+  fs: FileSystem,
+  files: string[],
+): ListFilesFn {
+  return function* (fileOrFolder: string): Iterable<FileInfo> {
+    for (const entry of fs.listFiles(fileOrFolder)) {
+      if (files.includes(entry.path)) {
+        yield entry;
+      }
+    }
+  };
+}
+
+interface Params {
+  readonly fs: FileSystem;
+  readonly path: {
+    resolve(...args: string[]): string;
+  };
+}
+
+export function createPushFileSystemBuilder({ fs, path }: Params) {
+  return async function (
+    client: GitHubClient,
+    context: Context,
+  ): Promise<[FileSystem, error]> {
+    const [prFiles, err] = await getPushFiles(client, context);
+    if (err !== null) {
+      return [fs, err];
+    }
+
+    const prFilePaths = prFiles.map((file) => path.resolve(".", file));
+
+    return [
+      {
+        listFiles: createListFiles(fs, prFilePaths),
+        readFile: fs.readFile,
+        writeFile: fs.writeFile,
+      },
+      null,
+    ];
+  };
+}
+
+export type {
+  Context as PushContext,
+};

--- a/src/file-systems/push.ts
+++ b/src/file-systems/push.ts
@@ -68,16 +68,16 @@ export function createPushFileSystemBuilder({ fs, path }: Params) {
     client: GitHubClient,
     context: Context,
   ): Promise<[FileSystem, error]> {
-    const [prFiles, err] = await getPushFiles(client, context);
+    const [pushedFiles, err] = await getPushFiles(client, context);
     if (err !== null) {
       return [fs, err];
     }
 
-    const prFilePaths = prFiles.map((file) => path.resolve(".", file));
+    const pushedFilesPaths = pushedFiles.map((file) => path.resolve(".", file));
 
     return [
       {
-        listFiles: createListFiles(fs, prFilePaths),
+        listFiles: createListFiles(fs, pushedFilesPaths),
         readFile: fs.readFile,
         writeFile: fs.writeFile,
       },

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,6 +4,9 @@ export type error = string | null;
 export type Context = {
   readonly eventName: string;
   readonly payload: {
+    readonly commits?: {
+      readonly id: string;
+    }[];
     readonly pull_request?: {
       readonly number: number;
     };

--- a/test/__mocks__/@actions/github.mock.ts
+++ b/test/__mocks__/@actions/github.mock.ts
@@ -24,6 +24,11 @@ function createGitHubMock(params?: Params): GitHubMock {
       .mockImplementation(() => {
         return {
           rest: {
+            repos: {
+              getCommit: jest.fn()
+                .mockReturnValue({ })
+                .mockName("client.rest.repos.getCommit"),
+            },
             pulls: {
               listFiles: jest.fn()
                 .mockReturnValue([])

--- a/test/__mocks__/clients.mock.ts
+++ b/test/__mocks__/clients.mock.ts
@@ -11,8 +11,14 @@ export default {
 };
 
 export const _sampleClient = {
+  commits: {
+    listFiles: jest.fn()
+      .mockResolvedValue([[], null])
+      .mockName("GitHubClient.commits.listFiles"),
+  },
   pulls: {
     listFiles: jest.fn()
+      .mockResolvedValue([[], null])
       .mockName("GitHubClient.pulls.listFiles"),
   },
 };

--- a/test/integration/clients.test.ts
+++ b/test/integration/clients.test.ts
@@ -69,6 +69,57 @@ describe("package clients", () => {
       client = new Client(octokit);
     });
 
+    describe("::commits", () => {
+      describe("::listFiles", () => {
+        beforeEach(() => {
+          octokit.rest.repos.getCommit.mockReset();
+        });
+
+        test.each([
+          [[/* no files */]],
+          [[{ filename: "foobar", status: "modified" }]],
+        ])("request success (files: `%p`)", async (files) => {
+          const owner = "pikachu";
+          const repo = "pokédex";
+          const ref = "commit-1";
+
+          octokit.rest.repos.getCommit.mockResolvedValueOnce({
+            data: { files },
+          });
+
+          const [result, err] = await client.commits.listFiles({
+            owner,
+            repo,
+            ref,
+          });
+
+          expect(err).toBeNull();
+          expect(result).toEqual(files);
+          expect(octokit.rest.repos.getCommit).toHaveBeenCalledWith({
+            owner,
+            repo,
+            ref,
+          });
+        });
+
+        test("request error", async () => {
+          const owner = "pikachu";
+          const repo = "pokédex";
+          const ref = "commit-1";
+
+          octokit.rest.repos.getCommit.mockRejectedValueOnce(new Error());
+
+          const [, err] = await client.commits.listFiles({
+            owner,
+            repo,
+            ref,
+          });
+
+          expect(err).not.toBeNull();
+        });
+      });
+    });
+
     describe("::pulls", () => {
       describe("::listFiles", () => {
         beforeEach(() => {

--- a/test/unit/clients/client.test.ts
+++ b/test/unit/clients/client.test.ts
@@ -15,6 +15,57 @@ describe("clients/client.ts", () => {
     client = new Client(octokit);
   });
 
+  describe("::commits", () => {
+    describe("::listFiles", () => {
+      beforeEach(() => {
+        octokit.rest.repos.getCommit.mockReset();
+      });
+
+      test.each([
+        [[/* no files */]],
+        [[{ filename: "foobar", status: "modified" }]],
+      ])("request success (files: `%p`)", async (files) => {
+        const owner = "pikachu";
+        const repo = "pokédex";
+        const ref = "commit-1";
+
+        octokit.rest.repos.getCommit.mockResolvedValueOnce({
+          data: { files },
+        });
+
+        const [result, err] = await client.commits.listFiles({
+          owner,
+          repo,
+          ref,
+        });
+
+        expect(err).toBeNull();
+        expect(result).toEqual(files);
+        expect(octokit.rest.repos.getCommit).toHaveBeenCalledWith({
+          owner,
+          repo,
+          ref,
+        });
+      });
+
+      test("request error", async () => {
+        const owner = "pikachu";
+        const repo = "pokédex";
+        const ref = "commit-1";
+
+        octokit.rest.pulls.listFiles.mockRejectedValueOnce(new Error());
+
+        const [, err] = await client.commits.listFiles({
+          owner,
+          repo,
+          ref,
+        });
+
+        expect(err).not.toBeNull();
+      });
+    });
+  });
+
   describe("::pulls", () => {
     describe("::listFiles", () => {
       beforeEach(() => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Add functionality such that the action will only optimize SVGs that have been changed the commits being pushed if it is running in the context of a push.