### PR TITLE
Don't error for invalid configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 ## [Unreleased, v2]
 
 - Only optimize SVGs in the pushed commits in that context. ([#382])
+- Don't error if there is a mistake in the Action options. ([#385])
 
 ## [2.0.0-alpha.4] - 2021-07-21
 
@@ -270,4 +271,5 @@ Versioning].
 [#378]: https://github.com/ericcornelissen/svgo-action/pull/378
 [#380]: https://github.com/ericcornelissen/svgo-action/pull/380
 [#382]: https://github.com/ericcornelissen/svgo-action/pull/382
+[#385]: https://github.com/ericcornelissen/svgo-action/pull/385
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,8 +34,7 @@ export default async function main({
 }: Params): Promise<void> {
   const [config, err0] = configs.New({ inp: core });
   if (err0 !== null) {
-    core.debug(err0);
-    return core.setFailed("Could not get Action configuration");
+    core.warning(`Your SVGO Action configuration is incorrect: ${err0}`);
   }
 
   const context = github.context;

--- a/test/unit/main.test.ts
+++ b/test/unit/main.test.ts
@@ -136,17 +136,16 @@ describe("main.ts", () => {
 
   describe("Failed run", () => {
     test("config error", async () => {
-      const err = errors.New("No configuration found");
+      const errMsg = "No configuration found";
+      const err = errors.New(errMsg);
       configsMock.New.mockReturnValueOnce([_sampleConfig, err]);
 
       await main({ core, github });
 
-      expect(core.setFailed).toHaveBeenCalledTimes(1);
-      expect(core.setFailed).toHaveBeenCalledWith(
-        expect.stringContaining("configuration"),
+      expect(core.setFailed).not.toHaveBeenCalled();
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining(errMsg),
       );
-
-      expect(core.debug).toHaveBeenCalledWith(err);
     });
 
     test("event error", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Change the behavior of the  action when there is an error in the configuration (e.g. a boolean value is not valid) from errorring to producing a warning.