### PR TITLE
Use code input defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 ## [Unreleased]
 
 - Don't require `repo-token` in scheduled and dispatched events. ([#396])
-- Change `svgo-config` default based on `svgo-version` value. ([#400])
+- Change `svgo-config` default based on `svgo-version` value. ([#400], [#402])
 - Add `repo-token` where missing to the documentation. ([#401])
 
 ## [2.0.0]
@@ -261,5 +261,6 @@ Versioning].
 [#396]: https://github.com/ericcornelissen/svgo-action/pull/396
 [#400]: https://github.com/ericcornelissen/svgo-action/pull/400
 [#401]: https://github.com/ericcornelissen/svgo-action/pull/401
+[#402]: https://github.com/ericcornelissen/svgo-action/pull/402
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/action.yml
+++ b/action.yml
@@ -5,24 +5,14 @@ author: 'Eric Cornelissen'
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
-    default: ''
-    required: false
   dry-run:
     description: 'Run the action in dry mode (i.e. do not write optimized SVGs)'
-    default: false
-    required: false
   ignore:
     description: 'A glob of SVGs that should not be optimized'
-    default: ''
-    required: false
   svgo-config:
     description: 'The path of the configuration file for SVGO'
-    default: 'svgo.config.js'
-    required: false
   svgo-version:
     description: 'The (major) SVGO version to be used (`1` or `2`)'
-    default: 2
-    required: false
 
 runs:
   using: 'node12'

--- a/src/inputs/getters.ts
+++ b/src/inputs/getters.ts
@@ -9,7 +9,7 @@ import {
 } from "../constants";
 import errors from "../errors";
 
-const INPUT_NOT_REQUIRED = { required: false };
+const GET_INPUT_OPTIONS = { required: true };
 
 interface Params<T> {
   readonly inp: Inputter;
@@ -22,16 +22,15 @@ function safeGetInput({
   inputName,
   defaultValue,
 }: Params<string>): [string, error] {
-  let result = defaultValue;
-  let err: error = null;
+  let result;
 
   try {
-    result = inp.getInput(inputName, INPUT_NOT_REQUIRED);
+    result = inp.getInput(inputName, GET_INPUT_OPTIONS);
   } catch (_) {
-    err = errors.New(`could not get input '${inputName}'`);
+    result = defaultValue;
   }
 
-  return [result, err];
+  return [result, null];
 }
 
 function safeGetBooleanInput({
@@ -39,16 +38,15 @@ function safeGetBooleanInput({
   inputName,
   defaultValue,
 }: Params<boolean>): [boolean, error] {
-  let result = defaultValue;
-  let err: error = null;
+  let result;
 
   try {
-    result = inp.getBooleanInput(inputName, INPUT_NOT_REQUIRED);
+    result = inp.getBooleanInput(inputName, GET_INPUT_OPTIONS);
   } catch (_) {
-    err = errors.New(`could not get input '${inputName}'`);
+    result = defaultValue;
   }
 
-  return [result, err];
+  return [result, null];
 }
 
 function safeGetNumericInput({
@@ -56,17 +54,16 @@ function safeGetNumericInput({
   inputName,
   defaultValue,
 }: Params<number>): [number, error] {
-  let result = defaultValue;
-  let err: error = null;
+  let result;
 
   try {
-    const _result = inp.getInput(inputName, INPUT_NOT_REQUIRED);
+    const _result = inp.getInput(inputName, GET_INPUT_OPTIONS);
     result = parseInt(_result, 10);
   } catch (_) {
-    err = errors.New(`could not get input '${inputName}'`);
+    result = defaultValue;
   }
 
-  return [result, err];
+  return [result, null];
 }
 
 function getIgnoreGlob(

--- a/test/unit/inputs/getters.test.ts
+++ b/test/unit/inputs/getters.test.ts
@@ -40,7 +40,7 @@ describe("inputs/getters.ts", () => {
         .mockImplementationOnce(() => { throw new Error(""); });
 
       const [result, err] = getIgnoreGlob(inp, defaultValue);
-      expect(err).not.toBeNull();
+      expect(err).toBeNull();
       expect(result).toEqual(defaultValue);
     });
   });
@@ -69,7 +69,7 @@ describe("inputs/getters.ts", () => {
         .mockImplementationOnce(() => { throw new Error(""); });
 
       const [result, err] = getIsDryRun(inp, defaultValue);
-      expect(err).not.toBeNull();
+      expect(err).toBeNull();
       expect(result).toEqual(defaultValue);
     });
   });
@@ -98,7 +98,7 @@ describe("inputs/getters.ts", () => {
         .mockImplementationOnce(() => { throw new Error(""); });
 
       const [result, err] = getSvgoConfigPath(inp, defaultValue);
-      expect(err).not.toBeNull();
+      expect(err).toBeNull();
       expect(result).toEqual(defaultValue);
     });
   });
@@ -142,7 +142,7 @@ describe("inputs/getters.ts", () => {
         .mockImplementationOnce(() => { throw new Error(""); });
 
       const [result, err] = getSvgoVersion(inp, defaultValue);
-      expect(err).not.toBeNull();
+      expect(err).toBeNull();
       expect(result).toEqual(defaultValue);
     });
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Following up on #400, this fixes a minor bug where the dynamic `svgo-config` value is not used due to the default in the Action manifest.
