### PR TITLE
Upgrade SVGO v2 from v2.4.0 to v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v2 to `v2.5.0`. ([#411])
 
 ## [1.3.6] - 2021-08-23
 
@@ -238,4 +238,5 @@ Versioning].
 [#371]: https://github.com/ericcornelissen/svgo-action/pull/371
 [#380]: https://github.com/ericcornelissen/svgo-action/pull/380
 [#407]: https://github.com/ericcornelissen/svgo-action/pull/407
+[#411]: https://github.com/ericcornelissen/svgo-action/pull/411
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -2975,7 +2975,8 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3417,9 +3418,9 @@
       }
     },
     "domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "requires": {
         "domelementtype": "^2.2.0"
       },
@@ -9928,19 +9929,24 @@
       }
     },
     "svgo-v2": {
-      "version": "npm:svgo@2.4.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.4.0.tgz",
-      "integrity": "sha512-W25S1UUm9Lm9VnE0TvCzL7aso/NCzDEaXLaElCUO/KaVitw0+IBicSVfM1L1c0YHK5TOFh73yQ2naCpVHEQ/OQ==",
+      "version": "npm:svgo@2.5.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.5.0.tgz",
+      "integrity": "sha512-FSdBOOo271VyF/qZnOn1PgwCdt1v4Dx0Sey+U1jgqm1vqRYjPGdip0RGrFW6ItwtkBB8rHgHk26dlVr0uCs82Q==",
       "requires": {
         "@trysound/sax": "0.1.1",
-        "colorette": "^1.2.2",
-        "commander": "^7.1.0",
+        "colorette": "^1.3.0",
+        "commander": "^7.2.0",
         "css-select": "^4.1.3",
-        "css-tree": "^1.1.2",
+        "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "stable": "^0.1.8"
       },
       "dependencies": {
+        "colorette": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+        },
         "css-select": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
@@ -9983,9 +9989,9 @@
           "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
         },
         "domutils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
           "requires": {
             "dom-serializer": "^1.0.1",
             "domelementtype": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "minimatch": "3.0.4",
     "node-eval": "2.0.0",
     "svgo-v1": "npm:svgo@1.3.2",
-    "svgo-v2": "npm:svgo@2.4.0"
+    "svgo-v2": "npm:svgo@2.5.0"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Upgrade the built-in SVGO v2 from version 2.4.0 to version 2.5.0 (latest)