### PR TITLE
Refactor input getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Fix bug when the `dry-run` value is invalid. ([#413])
 
 ## [2.0.3] - 2021-08-28
 
@@ -283,5 +283,6 @@ Versioning].
 [#406]: https://github.com/ericcornelissen/svgo-action/pull/406
 [#407]: https://github.com/ericcornelissen/svgo-action/pull/407
 [#410]: https://github.com/ericcornelissen/svgo-action/pull/410
+[#413]: https://github.com/ericcornelissen/svgo-action/pull/413
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/test/unit/inputs/getters.test.ts
+++ b/test/unit/inputs/getters.test.ts
@@ -12,8 +12,6 @@ import {
 } from "../../../src/inputs/getters";
 
 describe("inputs/getters.ts", () => {
-  const expectedGetInputOptions = { required: true };
-
   beforeEach(() => {
     resetAllWhenMocks();
   });
@@ -31,7 +29,7 @@ describe("inputs/getters.ts", () => {
     ])("can get input, single line ('%s')", (configuredValue) => {
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockReturnValueOnce(configuredValue);
+        .mockReturnValue(configuredValue);
 
       const [result, err] = getIgnoreGlobs(inp, "foobar");
       expect(err).toBeNull();
@@ -50,7 +48,7 @@ describe("inputs/getters.ts", () => {
     ])("can get input, multi line (%#)", (configuredValues, expectedValues) => {
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockReturnValueOnce(configuredValues);
+        .mockReturnValue(configuredValues);
 
       const [result, err] = getIgnoreGlobs(inp, "foobar");
       expect(err).toBeNull();
@@ -62,24 +60,11 @@ describe("inputs/getters.ts", () => {
 
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockImplementationOnce(() => { throw new Error(""); });
+        .mockImplementation(() => { throw new Error(""); });
 
       const [result, err] = getIgnoreGlobs(inp, defaultValue);
       expect(err).toBeNull();
       expect(result).toEqual([defaultValue]);
-    });
-
-    test("gets the input once", () => {
-      getIgnoreGlobs(inp, "foobar");
-      expect(inp.getInput).toHaveBeenCalledTimes(1);
-    });
-
-    test("gets the input as being required", () => {
-      getIgnoreGlobs(inp, "foobar");
-      expect(inp.getInput).toHaveBeenCalledWith(
-        expect.any(String),
-        expectedGetInputOptions,
-      );
     });
   });
 
@@ -96,7 +81,7 @@ describe("inputs/getters.ts", () => {
     ])("can get input (`%p`)", (configuredValue) => {
       when(inp.getBooleanInput)
         .calledWith(inputKey, expect.anything())
-        .mockReturnValueOnce(configuredValue);
+        .mockReturnValue(configuredValue);
 
       const [result, err] = getIsDryRun(inp, !configuredValue);
       expect(err).toBeNull();
@@ -108,24 +93,12 @@ describe("inputs/getters.ts", () => {
 
       when(inp.getBooleanInput)
         .calledWith(inputKey, expect.anything())
-        .mockImplementationOnce(() => { throw new Error(""); });
+        .mockImplementation(() => { throw new Error(""); });
 
       const [result, err] = getIsDryRun(inp, defaultValue);
-      expect(err).toBeNull();
-      expect(result).toEqual(defaultValue);
-    });
-
-    test("gets the input once", () => {
-      getIsDryRun(inp, false);
-      expect(inp.getBooleanInput).toHaveBeenCalledTimes(1);
-    });
-
-    test("gets the input as being required", () => {
-      getIsDryRun(inp, false);
-      expect(inp.getBooleanInput).toHaveBeenCalledWith(
-        expect.any(String),
-        expectedGetInputOptions,
-      );
+      expect(err).not.toBeNull();
+      expect(err).toContain("invalid dry-run value");
+      expect(result).toEqual(true);
     });
   });
 
@@ -142,7 +115,7 @@ describe("inputs/getters.ts", () => {
     ])("can get input ('%s')", (configuredValue) => {
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockReturnValueOnce(configuredValue);
+        .mockReturnValue(configuredValue);
 
       const [result, err] = getSvgoConfigPath(inp, "foo.bar");
       expect(err).toBeNull();
@@ -154,24 +127,11 @@ describe("inputs/getters.ts", () => {
 
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockImplementationOnce(() => { throw new Error(""); });
+        .mockImplementation(() => { throw new Error(""); });
 
       const [result, err] = getSvgoConfigPath(inp, defaultValue);
       expect(err).toBeNull();
       expect(result).toEqual(defaultValue);
-    });
-
-    test("gets the input once", () => {
-      getSvgoConfigPath(inp, "foo.bar");
-      expect(inp.getInput).toHaveBeenCalledTimes(1);
-    });
-
-    test("gets the input as being required", () => {
-      getSvgoConfigPath(inp, "foo.bar");
-      expect(inp.getInput).toHaveBeenCalledWith(
-        expect.any(String),
-        expectedGetInputOptions,
-      );
     });
   });
 
@@ -188,7 +148,7 @@ describe("inputs/getters.ts", () => {
     ])("can get input, valid (`%d`)", (configuredValue) => {
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockReturnValueOnce(`${configuredValue}`);
+        .mockReturnValue(`${configuredValue}`);
 
       const [result, err] = getSvgoVersion(inp, configuredValue === 1 ? 2 : 1);
       expect(err).toBeNull();
@@ -196,14 +156,31 @@ describe("inputs/getters.ts", () => {
     });
 
     test.each([
+      "0",
+      "3",
       "42",
+    ])("can get input, unsupported ('%s')", (configuredValue) => {
+      const defaultValue = 2;
+
+      when(inp.getInput)
+        .calledWith(inputKey, expect.anything())
+        .mockReturnValue(configuredValue);
+
+      const [result, err] = getSvgoVersion(inp, defaultValue);
+      expect(err).not.toBeNull();
+      expect(err).toContain("unsupported SVGO version");
+      expect(result).toEqual(defaultValue);
+    });
+
+    test.each([
       "foobar",
+      "Hello world",
     ])("can get input, invalid ('%s')", (configuredValue) => {
       const defaultValue = 2;
 
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockReturnValueOnce(configuredValue);
+        .mockReturnValue(configuredValue);
 
       const [result, err] = getSvgoVersion(inp, defaultValue);
       expect(err).not.toBeNull();
@@ -216,24 +193,11 @@ describe("inputs/getters.ts", () => {
 
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
-        .mockImplementationOnce(() => { throw new Error(""); });
+        .mockImplementation(() => { throw new Error(""); });
 
       const [result, err] = getSvgoVersion(inp, defaultValue);
       expect(err).toBeNull();
       expect(result).toEqual(defaultValue);
-    });
-
-    test("gets the input once", () => {
-      getSvgoVersion(inp, 2);
-      expect(inp.getInput).toHaveBeenCalledTimes(1);
-    });
-
-    test("gets the input as being required", () => {
-      getSvgoVersion(inp, 2);
-      expect(inp.getInput).toHaveBeenCalledWith(
-        expect.any(String),
-        expectedGetInputOptions,
-      );
     });
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Closes #409

Refactors the inputs package's getters module to distinguish provided and not-provided values, as well as valid and invalid values. This is then used to fix the issue where `dry-run`'s behaviour does not align with the documentation.

This refactoring was implemented with #386 in mind and will hopefully make it easier to resolve that.
