### PR TITLE
Add deprecation warning that v1 (general) support ends on 2022-05-31

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -100,4 +100,8 @@ export default async function main(): Promise<void> {
   run(client, config, svgo);
 }
 
+core.notice(`General support for SVGO Action v1 ends on 2022-05-31 and security
+updates will be supported until 2022-08-31. Please upgrade to SVGO Action v2 as
+soon as possible.`);
+
 main();

--- a/test/mocks/@actions/core.mock.ts
+++ b/test/mocks/@actions/core.mock.ts
@@ -33,6 +33,8 @@ export const getInput = jest.fn()
 
 export const info = jest.fn().mockName("core.info");
 
+export const notice = jest.fn().mockName("core.notice");
+
 export const setFailed = jest.fn().mockName("core.setFailed");
 
 export const setOutput = jest.fn().mockName("core.setOutput");


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] ~~I updated the documentation according to my changes.~~
- [n/a] ~~I added my change to the Changelog.~~

### Description

Add a deprecation notice using the newly added `core.notice` function.
