### PR TITLE
Use the action/core's `getMultilineInput` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 ## [Unreleased]
 
 - Fix bug when the `dry-run` value is invalid. ([#413])
+- Improve multiline support for ignore globs. ([#420])
 
 ## [2.0.3] - 2021-08-28
 
@@ -284,5 +285,6 @@ Versioning].
 [#407]: https://github.com/ericcornelissen/svgo-action/pull/407
 [#410]: https://github.com/ericcornelissen/svgo-action/pull/410
 [#413]: https://github.com/ericcornelissen/svgo-action/pull/413
+[#420]: https://github.com/ericcornelissen/svgo-action/pull/420
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/__mocks__/@actions/core.ts
+++ b/__mocks__/@actions/core.ts
@@ -26,6 +26,10 @@ const getInput = jest.fn()
   .mockImplementation(simulateGetInput)
   .mockName("core.getInput");
 
+const getMultilineInput = jest.fn()
+  .mockImplementation((key) => [simulateGetInput(key)])
+  .mockName("core.getMultilineInput");
+
 const info = jest.fn()
   .mockName("core.info");
 
@@ -42,6 +46,7 @@ export {
   debug,
   getBooleanInput,
   getInput,
+  getMultilineInput,
   info,
   setFailed,
   setOutput,

--- a/src/constants/inputs.ts
+++ b/src/constants/inputs.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_IGNORE_GLOBS = "";
+export const DEFAULT_IGNORE_GLOBS = [];
 export const DEFAULT_IS_DRY_RUN = false;
 export const DEFAULT_SVGO_V1_CONFIG_PATH = ".svgo.yml";
 export const DEFAULT_SVGO_V2_CONFIG_PATH = "svgo.config.js";

--- a/src/inputs/getters.ts
+++ b/src/inputs/getters.ts
@@ -9,8 +9,6 @@ import {
 } from "../constants";
 import errors from "../errors";
 
-const NEWLINE_EXPR = /\r?\n/;
-
 interface InputValue<T> {
   readonly value: T;
   readonly valid: boolean;
@@ -84,8 +82,8 @@ function getBooleanInput(params: Params<boolean>): InputValue<boolean> {
   return safeGetInput({ ...params, getInput: params.inp.getBooleanInput });
 }
 
-function getStringInput(params: Params<string>): InputValue<string> {
-  return safeGetInput({ ...params, getInput: params.inp.getInput });
+function getMultilineInput(params: Params<string[]>): InputValue<string[]> {
+  return safeGetInput({ ...params, getInput: params.inp.getMultilineInput });
 }
 
 function getNumericInput(params: Params<number>): InputValue<number> {
@@ -100,13 +98,18 @@ function getNumericInput(params: Params<number>): InputValue<number> {
   });
 }
 
+function getStringInput(params: Params<string>): InputValue<string> {
+  return safeGetInput({ ...params, getInput: params.inp.getInput });
+}
+
 function getIgnoreGlobs(
   inp: Inputter,
-  defaultValue: string,
+  _defaultValue: string,
 ): [string[], error] {
+  const defaultValue = [_defaultValue];
   const inputName = INPUT_NAME_IGNORE;
-  const input = getStringInput({ inp, inputName, defaultValue });
-  return [input.value.split(NEWLINE_EXPR), null];
+  const input = getMultilineInput({ inp, inputName, defaultValue });
+  return [input.value, null];
 }
 
 function getIsDryRun(

--- a/src/inputs/getters.ts
+++ b/src/inputs/getters.ts
@@ -104,9 +104,8 @@ function getStringInput(params: Params<string>): InputValue<string> {
 
 function getIgnoreGlobs(
   inp: Inputter,
-  _defaultValue: string,
+  defaultValue: string[],
 ): [string[], error] {
-  const defaultValue = [_defaultValue];
   const inputName = INPUT_NAME_IGNORE;
   const input = getMultilineInput({ inp, inputName, defaultValue });
   return [input.value, null];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,8 +36,9 @@ interface GitHub {
 
 // Type representing an object from which the Action inputs can be obtained.
 interface Inputter {
-  getInput(name: string, options: InputterOptions): string;
   getBooleanInput(name: string, options: InputterOptions): boolean;
+  getInput(name: string, options: InputterOptions): string;
+  getMultilineInput(name: string, options: InputterOptions): string[];
 }
 
 // Type representing the options for the `Inputter` interface.

--- a/test/__common__/inputter.mock.ts
+++ b/test/__common__/inputter.mock.ts
@@ -9,6 +9,9 @@ const inputter: InputterMock = {
   getInput: jest.fn()
     .mockReturnValue("")
     .mockName("inputter.getInput"),
+  getMultilineInput: jest.fn()
+    .mockReturnValue([])
+    .mockName("inputter.getMultilineInput"),
 };
 
 export default inputter;

--- a/test/integration/inputs.test.ts
+++ b/test/integration/inputs.test.ts
@@ -10,7 +10,7 @@ describe("package inputs", () => {
   const SVGO_CONFIG = "svgo-config";
   const SVGO_VERSION = "svgo-version";
 
-  const DEFAULT_IGNORE = "";
+  const DEFAULT_IGNORE = [""];
   const DEFAULT_DRY_RUN = false;
   const DEFAULT_SVGO_CONFIG = "svgo.config.js";
   const DEFAULT_SVGO_VERSION = 2;
@@ -23,7 +23,7 @@ describe("package inputs", () => {
   });
 
   beforeEach(() => {
-    when(inp.getInput)
+    when(inp.getMultilineInput)
       .calledWith(IGNORE, expect.anything())
       .mockReturnValue(DEFAULT_IGNORE);
 
@@ -41,8 +41,8 @@ describe("package inputs", () => {
   });
 
   describe("::ignoreGlobs", () => {
-    function doMockIgnoreInput(fn: () => string): void {
-      when(inp.getInput)
+    function doMockIgnoreInput(fn: () => string[]): void {
+      when(inp.getMultilineInput)
         .calledWith(IGNORE, expect.anything())
         .mockImplementation(fn);
     }
@@ -53,14 +53,14 @@ describe("package inputs", () => {
       const [config, err] = inputs.New({ inp });
 
       expect(err).toBeNull();
-      expect(config.ignoreGlobs).toEqual([DEFAULT_IGNORE]);
+      expect(config.ignoreGlobs).toEqual(DEFAULT_IGNORE);
     });
 
     test.each([
       "foo",
       "bar",
     ])("configured to '%s'", async (value) => {
-      doMockIgnoreInput(() => value);
+      doMockIgnoreInput(() => [value]);
 
       const [config, err] = inputs.New({ inp });
 

--- a/test/integration/inputs.test.ts
+++ b/test/integration/inputs.test.ts
@@ -10,7 +10,7 @@ describe("package inputs", () => {
   const SVGO_CONFIG = "svgo-config";
   const SVGO_VERSION = "svgo-version";
 
-  const DEFAULT_IGNORE = [""];
+  const DEFAULT_IGNORE = [];
   const DEFAULT_DRY_RUN = false;
   const DEFAULT_SVGO_CONFIG = "svgo.config.js";
   const DEFAULT_SVGO_VERSION = 2;

--- a/test/unit/inputs/getters.test.ts
+++ b/test/unit/inputs/getters.test.ts
@@ -27,9 +27,9 @@ describe("inputs/getters.ts", () => {
       "foobar",
       "Hello world!",
     ])("can get input, single line ('%s')", (configuredValue) => {
-      when(inp.getInput)
+      when(inp.getMultilineInput)
         .calledWith(inputKey, expect.anything())
-        .mockReturnValue(configuredValue);
+        .mockReturnValue([configuredValue]);
 
       const [result, err] = getIgnoreGlobs(inp, "foobar");
       expect(err).toBeNull();
@@ -37,22 +37,16 @@ describe("inputs/getters.ts", () => {
     });
 
     test.each([
-      [
-        "foo\nbar",
-        ["foo", "bar"],
-      ],
-      [
-        "Hello\r\nworld!",
-        ["Hello", "world!"],
-      ],
-    ])("can get input, multi line (%#)", (configuredValues, expectedValues) => {
-      when(inp.getInput)
+      [["foo", "bar"]],
+      [["Hello", "world!"]],
+    ])("can get input, multi line (%#)", (configuredValues) => {
+      when(inp.getMultilineInput)
         .calledWith(inputKey, expect.anything())
         .mockReturnValue(configuredValues);
 
       const [result, err] = getIgnoreGlobs(inp, "foobar");
       expect(err).toBeNull();
-      expect(result).toEqual(expectedValues);
+      expect(result).toEqual(configuredValues);
     });
 
     test("can't get input", () => {

--- a/test/unit/inputs/getters.test.ts
+++ b/test/unit/inputs/getters.test.ts
@@ -31,7 +31,7 @@ describe("inputs/getters.ts", () => {
         .calledWith(inputKey, expect.anything())
         .mockReturnValue([configuredValue]);
 
-      const [result, err] = getIgnoreGlobs(inp, "foobar");
+      const [result, err] = getIgnoreGlobs(inp, []);
       expect(err).toBeNull();
       expect(result).toEqual([configuredValue]);
     });
@@ -44,13 +44,13 @@ describe("inputs/getters.ts", () => {
         .calledWith(inputKey, expect.anything())
         .mockReturnValue(configuredValues);
 
-      const [result, err] = getIgnoreGlobs(inp, "foobar");
+      const [result, err] = getIgnoreGlobs(inp, []);
       expect(err).toBeNull();
       expect(result).toEqual(configuredValues);
     });
 
     test("can't get input", () => {
-      const defaultValue = "";
+      const defaultValue = [];
 
       when(inp.getInput)
         .calledWith(inputKey, expect.anything())
@@ -58,7 +58,7 @@ describe("inputs/getters.ts", () => {
 
       const [result, err] = getIgnoreGlobs(inp, defaultValue);
       expect(err).toBeNull();
-      expect(result).toEqual([defaultValue]);
+      expect(result).toEqual(defaultValue);
     });
   });
 

--- a/test/unit/inputs/index.test.ts
+++ b/test/unit/inputs/index.test.ts
@@ -52,7 +52,7 @@ describe("inputs/index.ts", () => {
         const [, err] = configs.New({ inp });
 
         expect(err).toBeNull();
-        expect(getters.getIgnoreGlobs).toHaveBeenCalledWith(inp, "");
+        expect(getters.getIgnoreGlobs).toHaveBeenCalledWith(inp, []);
       });
     });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Use `getMultilineInput` for [the `ignore` input](https://github.com/ericcornelissen/svgo-action/blob/main/docs/inputs.md#ignore).
