### PR TITLE
Upgrade SVGO v2 from v2.5.0 to v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v2 to `v2.6.0`. ([#426])
 
 ## [1.3.7] - 2021-08-30
 
@@ -243,4 +243,5 @@ Versioning].
 [#380]: https://github.com/ericcornelissen/svgo-action/pull/380
 [#407]: https://github.com/ericcornelissen/svgo-action/pull/407
 [#411]: https://github.com/ericcornelissen/svgo-action/pull/411
+[#426]: https://github.com/ericcornelissen/svgo-action/pull/426
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,9 +1612,9 @@
       "dev": true
     },
     "@trysound/sax": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
-      "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
     },
     "@types/babel__core": {
       "version": "7.1.15",
@@ -2646,8 +2646,7 @@
     "colorette": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
-      "dev": true
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -8380,11 +8379,11 @@
       }
     },
     "svgo-v2": {
-      "version": "npm:svgo@2.5.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.5.0.tgz",
-      "integrity": "sha512-FSdBOOo271VyF/qZnOn1PgwCdt1v4Dx0Sey+U1jgqm1vqRYjPGdip0RGrFW6ItwtkBB8rHgHk26dlVr0uCs82Q==",
+      "version": "npm:svgo@2.6.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.0.tgz",
+      "integrity": "sha512-ATpRmynNSjP/5hSM4Ij4Pg3L+BCN6IBES7wRLh1ZtVxJB7Xn8omiGttLW6v6ZbqrV5pCVB3XfdbUoY8IpgIwvw==",
       "requires": {
-        "@trysound/sax": "0.1.1",
+        "@trysound/sax": "0.2.0",
         "colorette": "^1.3.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
@@ -8393,11 +8392,6 @@
         "stable": "^0.1.8"
       },
       "dependencies": {
-        "colorette": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
-        },
         "css-select": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "minimatch": "3.0.4",
     "node-eval": "2.0.0",
     "svgo-v1": "npm:svgo@1.3.2",
-    "svgo-v2": "npm:svgo@2.5.0"
+    "svgo-v2": "npm:svgo@2.6.0"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [ ] I left no linting errors in my changes.
- [n/a] ~~I tested my changes.~~
- [n/a] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Upgrade the built-in SVGO v2 from version 2.5.0 to version 2.6.0 (latest)
