### PR TITLE
Upgrade SVGO v2 from v2.5.0 to v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 - Fix bug when the `dry-run` value is invalid. ([#413])
 - Improve multiline support for ignore globs. ([#420])
 - Fix mistake in the Pull Request example workflow. ([#424])
+- Update SVGO v2 to `v2.6.0`. ([#427])
 
 ## [2.0.3] - 2021-08-28
 
@@ -288,5 +289,6 @@ Versioning].
 [#413]: https://github.com/ericcornelissen/svgo-action/pull/413
 [#420]: https://github.com/ericcornelissen/svgo-action/pull/420
 [#424]: https://github.com/ericcornelissen/svgo-action/pull/424
+[#427]: https://github.com/ericcornelissen/svgo-action/pull/427
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "minimatch": "3.0.4",
         "node-eval": "2.0.0",
         "svgo-v1": "npm:svgo@1.3.2",
-        "svgo-v2": "npm:svgo@2.5.0"
+        "svgo-v2": "npm:svgo@2.6.0"
       },
       "devDependencies": {
         "@commitlint/cli": "13.1.0",
@@ -2521,9 +2521,9 @@
       }
     },
     "node_modules/@trysound/sax": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
-      "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "engines": {
         "node": ">=10.13.0"
       }
@@ -11753,11 +11753,11 @@
     },
     "node_modules/svgo-v2": {
       "name": "svgo",
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.5.0.tgz",
-      "integrity": "sha512-FSdBOOo271VyF/qZnOn1PgwCdt1v4Dx0Sey+U1jgqm1vqRYjPGdip0RGrFW6ItwtkBB8rHgHk26dlVr0uCs82Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.0.tgz",
+      "integrity": "sha512-ATpRmynNSjP/5hSM4Ij4Pg3L+BCN6IBES7wRLh1ZtVxJB7Xn8omiGttLW6v6ZbqrV5pCVB3XfdbUoY8IpgIwvw==",
       "dependencies": {
-        "@trysound/sax": "0.1.1",
+        "@trysound/sax": "0.2.0",
         "colorette": "^1.3.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
@@ -14684,9 +14684,9 @@
       "dev": true
     },
     "@trysound/sax": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
-      "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
     },
     "@types/babel__core": {
       "version": "7.1.14",
@@ -21650,11 +21650,11 @@
       }
     },
     "svgo-v2": {
-      "version": "npm:svgo@2.5.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.5.0.tgz",
-      "integrity": "sha512-FSdBOOo271VyF/qZnOn1PgwCdt1v4Dx0Sey+U1jgqm1vqRYjPGdip0RGrFW6ItwtkBB8rHgHk26dlVr0uCs82Q==",
+      "version": "npm:svgo@2.6.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.0.tgz",
+      "integrity": "sha512-ATpRmynNSjP/5hSM4Ij4Pg3L+BCN6IBES7wRLh1ZtVxJB7Xn8omiGttLW6v6ZbqrV5pCVB3XfdbUoY8IpgIwvw==",
       "requires": {
-        "@trysound/sax": "0.1.1",
+        "@trysound/sax": "0.2.0",
         "colorette": "^1.3.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "minimatch": "3.0.4",
     "node-eval": "2.0.0",
     "svgo-v1": "npm:svgo@1.3.2",
-    "svgo-v2": "npm:svgo@2.5.0"
+    "svgo-v2": "npm:svgo@2.6.0"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Upgrade the built-in SVGO v2 from version 2.5.0 to version 2.6.0 (latest)