### PR TITLE
Upgrade SVGO v2 from v2.6.0 to v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v2 to `v2.6.1`. ([#429])
 
 ## [1.3.8] - 2021-09-13
 
@@ -248,4 +248,5 @@ Versioning].
 [#407]: https://github.com/ericcornelissen/svgo-action/pull/407
 [#411]: https://github.com/ericcornelissen/svgo-action/pull/411
 [#426]: https://github.com/ericcornelissen/svgo-action/pull/426
+[#429]: https://github.com/ericcornelissen/svgo-action/pull/429
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -2646,7 +2646,8 @@
     "colorette": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -4056,6 +4057,15 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -7157,21 +7167,22 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -7237,21 +7248,22 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -8379,12 +8391,12 @@
       }
     },
     "svgo-v2": {
-      "version": "npm:svgo@2.6.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.0.tgz",
-      "integrity": "sha512-ATpRmynNSjP/5hSM4Ij4Pg3L+BCN6IBES7wRLh1ZtVxJB7Xn8omiGttLW6v6ZbqrV5pCVB3XfdbUoY8IpgIwvw==",
+      "version": "npm:svgo@2.6.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.1.tgz",
+      "integrity": "sha512-SDo274ymyG1jJ3HtCr3hkfwS8NqWdF0fMr6xPlrJ5y2QMofsQxIEFWgR1epwb197teKGgnZbzozxvJyIeJpE2Q==",
       "requires": {
         "@trysound/sax": "0.2.0",
-        "colorette": "^1.3.0",
+        "colorette": "^1.4.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
@@ -8392,6 +8404,11 @@
         "stable": "^0.1.8"
       },
       "dependencies": {
+        "colorette": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+          "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
+        },
         "css-select": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
@@ -8449,9 +8466,9 @@
           "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
         },
         "nth-check": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-          "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+          "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
           "requires": {
             "boolbase": "^1.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "minimatch": "3.0.4",
     "node-eval": "2.0.0",
     "svgo-v1": "npm:svgo@1.3.2",
-    "svgo-v2": "npm:svgo@2.6.0"
+    "svgo-v2": "npm:svgo@2.6.1"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Upgrade the built-in SVGO v2 from version 2.6.0 to version 2.6.1 (latest)
