### PR TITLE
Upgrade SVGO v2 from v2.6.0 to v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v2 to `v2.6.1`. ([#430])
 
 ## [2.0.4] - 2021-09-14
 
@@ -304,5 +304,6 @@ Versioning].
 [#424]: https://github.com/ericcornelissen/svgo-action/pull/424
 [#426]: https://github.com/ericcornelissen/svgo-action/pull/426
 [#427]: https://github.com/ericcornelissen/svgo-action/pull/427
+[#430]: https://github.com/ericcornelissen/svgo-action/pull/430
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "minimatch": "3.0.4",
         "node-eval": "2.0.0",
         "svgo-v1": "npm:svgo@1.3.2",
-        "svgo-v2": "npm:svgo@2.6.0"
+        "svgo-v2": "npm:svgo@2.6.1"
       },
       "devDependencies": {
         "@commitlint/cli": "13.1.0",
@@ -3821,9 +3821,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -11753,12 +11753,12 @@
     },
     "node_modules/svgo-v2": {
       "name": "svgo",
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.0.tgz",
-      "integrity": "sha512-ATpRmynNSjP/5hSM4Ij4Pg3L+BCN6IBES7wRLh1ZtVxJB7Xn8omiGttLW6v6ZbqrV5pCVB3XfdbUoY8IpgIwvw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.1.tgz",
+      "integrity": "sha512-SDo274ymyG1jJ3HtCr3hkfwS8NqWdF0fMr6xPlrJ5y2QMofsQxIEFWgR1epwb197teKGgnZbzozxvJyIeJpE2Q==",
       "dependencies": {
         "@trysound/sax": "0.2.0",
-        "colorette": "^1.3.0",
+        "colorette": "^1.4.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
@@ -15653,9 +15653,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -21650,12 +21650,12 @@
       }
     },
     "svgo-v2": {
-      "version": "npm:svgo@2.6.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.0.tgz",
-      "integrity": "sha512-ATpRmynNSjP/5hSM4Ij4Pg3L+BCN6IBES7wRLh1ZtVxJB7Xn8omiGttLW6v6ZbqrV5pCVB3XfdbUoY8IpgIwvw==",
+      "version": "npm:svgo@2.6.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.1.tgz",
+      "integrity": "sha512-SDo274ymyG1jJ3HtCr3hkfwS8NqWdF0fMr6xPlrJ5y2QMofsQxIEFWgR1epwb197teKGgnZbzozxvJyIeJpE2Q==",
       "requires": {
         "@trysound/sax": "0.2.0",
-        "colorette": "^1.3.0",
+        "colorette": "^1.4.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "minimatch": "3.0.4",
     "node-eval": "2.0.0",
     "svgo-v1": "npm:svgo@1.3.2",
-    "svgo-v2": "npm:svgo@2.6.0"
+    "svgo-v2": "npm:svgo@2.6.1"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Upgrade the built-in SVGO v2 from version 2.6.0 to version 2.6.1 (latest)
