### PR TITLE
Upgrade SVGO from v2.7.0 to v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v2 to `v2.8.0`. ([#481])
 
 ## [2.1.2] - 2021-10-18
 
@@ -357,5 +357,6 @@ Versioning].
 [#464]: https://github.com/ericcornelissen/svgo-action/pull/464
 [#466]: https://github.com/ericcornelissen/svgo-action/pull/466
 [#469]: https://github.com/ericcornelissen/svgo-action/pull/469
+[#481]: https://github.com/ericcornelissen/svgo-action/pull/481
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "minimatch": "3.0.4",
         "node-eval": "2.0.0",
         "svgo-v1": "npm:svgo@1.3.2",
-        "svgo-v2": "npm:svgo@2.7.0"
+        "svgo-v2": "npm:svgo@2.8.0"
       },
       "devDependencies": {
         "@commitlint/cli": "14.1.0",
@@ -8503,11 +8503,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "node_modules/nanocolors": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
-      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9121,6 +9116,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -10150,16 +10150,16 @@
     },
     "node_modules/svgo-v2": {
       "name": "svgo",
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.7.0.tgz",
-      "integrity": "sha512-aDLsGkre4fTDCWvolyW+fs8ZJFABpzLXbtdK1y71CKnHzAnpDxKXPj2mNKj+pyOXUCzFHzuxRJ94XOFygOWV3w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
-        "nanocolors": "^0.1.12",
+        "picocolors": "^1.0.0",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -17414,11 +17414,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "nanocolors": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
-      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17864,6 +17859,11 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -18628,16 +18628,16 @@
       }
     },
     "svgo-v2": {
-      "version": "npm:svgo@2.7.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.7.0.tgz",
-      "integrity": "sha512-aDLsGkre4fTDCWvolyW+fs8ZJFABpzLXbtdK1y71CKnHzAnpDxKXPj2mNKj+pyOXUCzFHzuxRJ94XOFygOWV3w==",
+      "version": "npm:svgo@2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
       "requires": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
-        "nanocolors": "^0.1.12",
+        "picocolors": "^1.0.0",
         "stable": "^0.1.8"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "3.0.4",
     "node-eval": "2.0.0",
     "svgo-v1": "npm:svgo@1.3.2",
-    "svgo-v2": "npm:svgo@2.7.0"
+    "svgo-v2": "npm:svgo@2.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "14.1.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [n/a] ~~I tested my changes.~~
- [n/a] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Upgrade the built-in SVGO v2 from version 2.7.0 to version 2.8.0 (latest)
