### PR TITLE
Disable RenovateBot automerging

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,11 +11,6 @@
 
   packageRules: [
     {
-      // Configure automerge: exclude semver major changes
-      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
-      automerge: true,
-    },
-    {
       // Configure @vercel/ncc: don't upgrade beyond v0.30.0
       // See: https://github.com/ericcornelissen/svgo-action/issues/425
       matchPackageNames: ["@vercel/ncc"],
@@ -45,10 +40,6 @@
     // This schedule should be the same as the general schedule!
     schedule: "on the first day of the month",
   },
-
-  // Enable automerging of Renovate Pull Requests
-  automerge: true,
-  automergeType: "pr",
 
   // Schedule PRs to be created once every two weeks
   schedule: "on the first day of the month",


### PR DESCRIPTION

<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [ ] I left no linting errors in my changes.
- [ ] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

Disable [RenovateBot](https://renovatebot.com)'s automerging feature. This was done mainly with security in mind, reducing (if only slightly) the chances of a malicious package updates from ending up in the project.