### PR TITLE
Fix ts-jest `mocked` deprecation warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,13 +98,8 @@ module.exports = {
           "group": "builtin",
           "position": "before",
         },
-        {
-          "pattern": "ts-jest/utils",
-          "group": "builtin",
-          "position": "before",
-        },
       ],
-      "pathGroupsExcludedImportTypes": ["ts-jest/utils"],
+      "pathGroupsExcludedImportTypes": [],
     }],
 
     // eslint-plugin-jest

--- a/test/integration/action-management.test.ts
+++ b/test/integration/action-management.test.ts
@@ -1,13 +1,12 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/core");
 
-import * as _core from "@actions/core";
+import * as core from "@actions/core";
 
 import actionManagement from "../../src/action-management";
 import errors from "../../src/errors";
 
-const core = mocked(_core);
+const coreSetFailed = core.setFailed as jest.MockedFunction<typeof core.setFailed>; // eslint-disable-line max-len
+const coreWarning = core.warning as jest.MockedFunction<typeof core.warning>;
 
 describe("package action-management", () => {
   describe.each([
@@ -22,13 +21,11 @@ describe("package action-management", () => {
 
     beforeEach(() => {
       action = actionManagement.New({ core, config });
-
-      core.setFailed.mockClear();
     });
 
     describe("::failIf", () => {
       beforeEach(() => {
-        core.setFailed.mockClear();
+        coreSetFailed.mockClear();
       });
 
       test("condition is `true`", async () => {
@@ -62,8 +59,8 @@ describe("package action-management", () => {
       const callbackFn = strict ? core.setFailed : core.warning;
 
       beforeEach(() => {
-        core.setFailed.mockClear();
-        core.warning.mockClear();
+        coreSetFailed.mockClear();
+        coreWarning.mockClear();
       });
 
       test("condition is `true`", async () => {

--- a/test/integration/file-systems.test.ts
+++ b/test/integration/file-systems.test.ts
@@ -1,14 +1,16 @@
 import type { Dirent, Stats } from "fs";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("fs");
 
-import * as _fs from "fs";
+import * as fs from "fs";
 
 import fileSystems from "../../src/file-systems";
 
-const fs = mocked(_fs);
+const fsExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+const fsLstatSync = fs.lstatSync as jest.MockedFunction<typeof fs.lstatSync>;
+const fsReaddirSync = fs.readdirSync as jest.MockedFunction<typeof fs.readdirSync>; // eslint-disable-line max-len
+const fsReadFileSync = fs.readFileSync as jest.MockedFunction<typeof fs.readFileSync>; // eslint-disable-line max-len
+const fsWriteFileSync = fs.writeFileSync as jest.MockedFunction<typeof fs.writeFileSync>; // eslint-disable-line max-len
 
 describe("package file-systems", () => {
   const NO_FILTERS = [];
@@ -28,13 +30,13 @@ describe("package file-systems", () => {
       const folder1file1 = "folder1/file1" as unknown as Dirent;
       const file1 = "file1" as unknown as Dirent;
 
-      fs.readdirSync.mockReturnValueOnce([folder1, file1]);
-      fs.readdirSync.mockReturnValueOnce([folder1file1]);
-      fs.existsSync.mockReturnValue(true);
+      fsReaddirSync.mockReturnValueOnce([folder1, file1]);
+      fsReaddirSync.mockReturnValueOnce([folder1file1]);
+      fsExistsSync.mockReturnValue(true);
 
-      fs.lstatSync.mockReturnValueOnce(lstatDir);
-      fs.lstatSync.mockReturnValueOnce(lstatFile);
-      fs.lstatSync.mockReturnValueOnce(lstatFile);
+      fsLstatSync.mockReturnValueOnce(lstatDir);
+      fsLstatSync.mockReturnValueOnce(lstatFile);
+      fsLstatSync.mockReturnValueOnce(lstatFile);
 
       const fileSystem = fileSystems.New({ filters });
 
@@ -49,13 +51,13 @@ describe("package file-systems", () => {
       const folder1file1 = "folder1/file1" as unknown as Dirent;
       const file1 = "file1" as unknown as Dirent;
 
-      fs.readdirSync.mockReturnValueOnce([folder1, file1]);
-      fs.readdirSync.mockReturnValueOnce([folder1file1]);
-      fs.existsSync.mockReturnValue(true);
+      fsReaddirSync.mockReturnValueOnce([folder1, file1]);
+      fsReaddirSync.mockReturnValueOnce([folder1file1]);
+      fsExistsSync.mockReturnValue(true);
 
-      fs.lstatSync.mockReturnValueOnce(lstatDir);
-      fs.lstatSync.mockReturnValueOnce(lstatFile);
-      fs.lstatSync.mockReturnValueOnce(lstatFile);
+      fsLstatSync.mockReturnValueOnce(lstatDir);
+      fsLstatSync.mockReturnValueOnce(lstatFile);
+      fsLstatSync.mockReturnValueOnce(lstatFile);
 
       const fileSystem = fileSystems.New({ filters });
 
@@ -68,16 +70,16 @@ describe("package file-systems", () => {
     const fileHandle = { path: "foo.bar" };
 
     beforeEach(() => {
-      fs.existsSync.mockClear();
-      fs.readFileSync.mockClear();
+      fsExistsSync.mockClear();
+      fsReadFileSync.mockClear();
     });
 
     test("success", async () => {
       const filters = NO_FILTERS;
       const fileContent = "Hello world!";
 
-      fs.existsSync.mockReturnValueOnce(true);
-      fs.readFileSync.mockReturnValueOnce(fileContent);
+      fsExistsSync.mockReturnValueOnce(true);
+      fsReadFileSync.mockReturnValueOnce(fileContent);
 
       const fileSystem = fileSystems.New({ filters });
 
@@ -89,8 +91,8 @@ describe("package file-systems", () => {
     test("read failure", async () => {
       const filters = NO_FILTERS;
 
-      fs.existsSync.mockReturnValueOnce(true);
-      fs.readFileSync.mockImplementationOnce(() => { throw new Error(); });
+      fsExistsSync.mockReturnValueOnce(true);
+      fsReadFileSync.mockImplementationOnce(() => { throw new Error(); });
 
       const fileSystem = fileSystems.New({ filters });
 
@@ -101,7 +103,7 @@ describe("package file-systems", () => {
     test("file does not exists", async () => {
       const filters = NO_FILTERS;
 
-      fs.existsSync.mockReturnValueOnce(false);
+      fsExistsSync.mockReturnValueOnce(false);
 
       const fileSystem = fileSystems.New({ filters });
 
@@ -112,7 +114,7 @@ describe("package file-systems", () => {
     test("file is filtered out", async () => {
       const filters = [() => false];
 
-      fs.existsSync.mockReturnValueOnce(true);
+      fsExistsSync.mockReturnValueOnce(true);
 
       const fileSystem = fileSystems.New({ filters });
 
@@ -126,7 +128,7 @@ describe("package file-systems", () => {
     const fileContent = "Hello world!";
 
     beforeEach(() => {
-      fs.writeFileSync.mockClear();
+      fsWriteFileSync.mockClear();
     });
 
     test("success", async () => {
@@ -141,7 +143,7 @@ describe("package file-systems", () => {
     test("write failure", async () => {
       const filters = NO_FILTERS;
 
-      fs.writeFileSync.mockImplementationOnce(() => { throw new Error(); });
+      fsWriteFileSync.mockImplementationOnce(() => { throw new Error(); });
 
       const fileSystem = fileSystems.New({ filters });
 
@@ -152,7 +154,7 @@ describe("package file-systems", () => {
     test("file is filtered out", async () => {
       const filters = [() => false];
 
-      fs.existsSync.mockReturnValueOnce(true);
+      fsExistsSync.mockReturnValueOnce(true);
 
       const fileSystem = fileSystems.New({ filters });
 

--- a/test/integration/filters.test.ts
+++ b/test/integration/filters.test.ts
@@ -1,16 +1,12 @@
-import { mocked } from "ts-jest/utils";
-
 jest.dontMock("minimatch");
 
 jest.mock("@actions/github");
 
-import * as _github from "@actions/github";
+import * as github from "@actions/github";
 
 import clients from "../../src/clients";
 import filters from "../../src/filters";
 import inp from "../__common__/inputter.mock";
-
-const github = mocked(_github);
 
 describe("package filters", () => {
   describe("::NewGlobFilter", () => {

--- a/test/integration/helpers.test.ts
+++ b/test/integration/helpers.test.ts
@@ -1,8 +1,6 @@
 import type { SupportedSvgoVersions } from "../../src/svgo";
 import type { Octokit } from "../../src/types";
 
-import { mocked } from "ts-jest/utils";
-
 jest.dontMock("js-yaml");
 jest.dontMock("minimatch");
 jest.dontMock("node-eval");
@@ -11,9 +9,7 @@ jest.mock("@actions/core");
 jest.mock("@actions/github");
 
 import * as core from "@actions/core";
-import * as _github from "@actions/github";
-
-const github = mocked(_github);
+import * as github from "@actions/github";
 
 import clients from "../../src/clients";
 import {
@@ -24,6 +20,8 @@ import {
   parseRawSvgoConfig,
 } from "../../src/helpers";
 import inp from "../__common__/inputter.mock";
+
+const githubGetOctokit = github.getOctokit as jest.MockedFunction<typeof github.getOctokit>; // eslint-disable-line max-len
 
 describe("package helpers", () => {
   const EVENT_PULL_REQUEST = "pull_request";
@@ -65,7 +63,7 @@ describe("package helpers", () => {
         fileNotSvg,
         fileSvgInFolderFoo,
       ].map((filename) => ({ filename, status: STATUS_ADDED }));
-      github.getOctokit.mockReturnValueOnce({
+      githubGetOctokit.mockReturnValueOnce({
         rest: {
           repos: {
             getCommit: jest.fn()

--- a/test/integration/main.test.ts
+++ b/test/integration/main.test.ts
@@ -1,19 +1,18 @@
 import type { Dirent } from "fs";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/core");
 jest.mock("@actions/github");
 jest.mock("fs");
 
-import * as _fs from "fs";
+import * as fs from "fs";
 
-import * as _core from "@actions/core";
-import * as _github from "@actions/github";
+import * as core from "@actions/core";
+import * as github from "@actions/github";
 
-const core = mocked(_core);
-const fs = mocked(_fs);
-const github = mocked(_github);
+const coreSetOutput = core.setOutput as jest.MockedFunction<typeof core.setOutput>; // eslint-disable-line max-len
+const fsExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>; // eslint-disable-line max-len
+const fsReaddirSync = fs.readdirSync as jest.MockedFunction<typeof fs.readdirSync>; // eslint-disable-line max-len
+const fsReadFileSync = fs.readFileSync as jest.MockedFunction<typeof fs.readFileSync>; // eslint-disable-line max-len
 
 import main from "../../src/main";
 
@@ -27,9 +26,9 @@ describe("main", () => {
   ];
 
   beforeEach(() => {
-    core.setOutput.mockClear();
+    coreSetOutput.mockClear();
 
-    fs.readFileSync.mockClear();
+    fsReadFileSync.mockClear();
   });
 
   test.each(ALL_EVENTS)("reads SVGs ('%s')", async (eventName) => {
@@ -38,8 +37,8 @@ describe("main", () => {
     const file1 = "file1.svg" as unknown as Dirent;
     const file2 = "file2.svg" as unknown as Dirent;
 
-    fs.readdirSync.mockReturnValue([file1, file2]);
-    fs.existsSync.mockReturnValue(true);
+    fsReaddirSync.mockReturnValue([file1, file2]);
+    fsExistsSync.mockReturnValue(true);
 
     await main({ core, github });
 

--- a/test/integration/svgo.test.ts
+++ b/test/integration/svgo.test.ts
@@ -1,7 +1,5 @@
 import type { SupportedSvgoVersions } from "../../src/svgo";
 
-import { mocked } from "ts-jest/utils";
-
 jest.dontMock("js-yaml"); // used by svgo-v1
 jest.dontMock("svgo-v1");
 jest.dontMock("svgo-v2");
@@ -14,7 +12,7 @@ import svgoV2 from "svgo-v2"; // eslint-disable-line import/default
 
 import SVGO from "../../src/svgo";
 
-const importCwdSilent = mocked(importCwd.silent);
+const importCwdSilent = importCwd.silent as jest.MockedFunction<typeof importCwd.silent>; // eslint-disable-line max-len
 
 describe("package svgo", () => {
   const consoleErrorBackup = console.error; // eslint-disable-line no-console

--- a/test/unit/action-management/action-manager.test.ts
+++ b/test/unit/action-management/action-manager.test.ts
@@ -1,17 +1,15 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/core");
 jest.mock("../../../src/action-management/helpers");
 jest.mock("../../../src/errors");
 
-import * as _core from "@actions/core";
+import * as core from "@actions/core";
 
 import StandardActionManager from "../../../src/action-management/action-manager"; // eslint-disable-line max-len
-import * as _helpers from "../../../src/action-management/helpers";
+import * as helpers from "../../../src/action-management/helpers";
 import errors from "../../../src/errors";
 
-const core = mocked(_core);
-const helpers = mocked(_helpers);
+const coreSetFailed = core.setFailed as jest.MockedFunction<typeof core.setFailed>; // eslint-disable-line max-len
+const helpersRunIf = helpers.runIf as jest.MockedFunction<typeof helpers.runIf>;
 
 describe("action-management/action-manager.ts", () => {
   const testConditions = [
@@ -31,8 +29,8 @@ describe("action-management/action-manager.ts", () => {
     });
 
     beforeEach(() => {
-      helpers.runIf.mockClear();
-      core.setFailed.mockClear();
+      coreSetFailed.mockClear();
+      helpersRunIf.mockClear();
     });
 
     test.each([
@@ -44,7 +42,7 @@ describe("action-management/action-manager.ts", () => {
     });
 
     test("calls the correct function", () => {
-      helpers.runIf.mockImplementationOnce((_, fn) => fn());
+      helpersRunIf.mockImplementationOnce((_, fn) => fn());
 
       actionManager.failIf(false, msg);
       expect(core.setFailed).toHaveBeenCalledTimes(1);
@@ -62,8 +60,8 @@ describe("action-management/action-manager.ts", () => {
     });
 
     beforeEach(() => {
-      helpers.runIf.mockClear();
-      core.setFailed.mockClear();
+      coreSetFailed.mockClear();
+      helpersRunIf.mockClear();
     });
 
     test.each([
@@ -77,7 +75,7 @@ describe("action-management/action-manager.ts", () => {
     test("calls the correct function", () => {
       const callbackFn = strict ? core.setFailed : core.warning; // eslint-disable-line jest/no-if
 
-      helpers.runIf.mockImplementationOnce((_, fn) => fn());
+      helpersRunIf.mockImplementationOnce((_, fn) => fn());
 
       actionManager.strictFailIf(false, msg);
       expect(callbackFn).toHaveBeenCalledTimes(1);

--- a/test/unit/action-management/index.test.ts
+++ b/test/unit/action-management/index.test.ts
@@ -1,20 +1,17 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/core");
 jest.mock("../../../src/action-management/action-manager");
 
-import * as _core from "@actions/core";
+import * as core from "@actions/core";
 
-import _ActionManager from "../../../src/action-management/action-manager";
+import ActionManager from "../../../src/action-management/action-manager";
 import actionManagement from "../../../src/action-management/index";
 
-const ActionManager = mocked(_ActionManager);
-const core = mocked(_core);
+const ActionManagerMock = ActionManager as jest.MockedClass<typeof ActionManager>; // eslint-disable-line max-len
 
 describe("action-management/index.ts", () => {
   describe("::New", () => {
     beforeEach(() => {
-      ActionManager.mockClear();
+      ActionManagerMock.mockClear();
     });
 
     test.each([true, false])("strict=%s", (strict) => {

--- a/test/unit/clients/index.test.ts
+++ b/test/unit/clients/index.test.ts
@@ -1,15 +1,11 @@
 import { when, resetAllWhenMocks } from "jest-when";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("../../../src/clients/client");
 jest.mock("../../../src/errors");
 
-import _Client from "../../../src/clients/client";
+import Client from "../../../src/clients/client";
 import clients from "../../../src/clients/index";
 import inp from "../../__common__/inputter.mock";
-
-const Client = mocked(_Client);
 
 describe("clients/index.ts", () => {
   let github, getOctokit;

--- a/test/unit/file-systems/index.test.ts
+++ b/test/unit/file-systems/index.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("fs");
 jest.mock("path");
 jest.mock("../../../src/file-systems/base");
@@ -8,17 +6,17 @@ jest.mock("../../../src/file-systems/filtered");
 import * as fs from "fs";
 import * as path from "path";
 
-import _NewBaseFileSystem from "../../../src/file-systems/base";
-import _NewFilteredFileSystem from "../../../src/file-systems/filtered";
+import NewBaseFileSystem from "../../../src/file-systems/base";
+import NewFilteredFileSystem from "../../../src/file-systems/filtered";
 import fileSystems from "../../../src/file-systems/index";
 
-const NewBaseFileSystem = mocked(_NewBaseFileSystem);
-const NewFilteredFileSystem = mocked(_NewFilteredFileSystem);
+const NewBaseFileSystemMock = NewBaseFileSystem as jest.MockedFunction<typeof NewBaseFileSystem>; // eslint-disable-line max-len
+const NewFilteredFileSystemMock = NewFilteredFileSystem as jest.MockedFunction<typeof NewFilteredFileSystem>; // eslint-disable-line max-len
 
 describe("file-systems/index.ts", () => {
   beforeEach(() => {
-    NewBaseFileSystem.mockClear();
-    NewFilteredFileSystem.mockClear();
+    NewBaseFileSystemMock.mockClear();
+    NewFilteredFileSystemMock.mockClear();
   });
 
   describe("::New", () => {

--- a/test/unit/filters/glob.test.ts
+++ b/test/unit/filters/glob.test.ts
@@ -2,23 +2,23 @@ import type { IMinimatch } from "minimatch";
 
 jest.mock("minimatch");
 
-import * as minimatch from "minimatch";
+import { Minimatch } from "minimatch";
 
 import New from "../../../src/filters/glob";
 
-const Minimatch = minimatch.Minimatch as jest.MockedClass<typeof minimatch.Minimatch>; // eslint-disable-line max-len
+const MinimatchMock = Minimatch as jest.MockedClass<typeof Minimatch>;
 
 describe("filters/glob.ts", () => {
   describe("::New", () => {
     beforeEach(() => {
-      Minimatch.mockClear();
+      MinimatchMock.mockClear();
     });
 
     test("a file matching the glob", () => {
       const query = "foo/bar.svg";
 
       const match = jest.fn().mockReturnValue(true);
-      Minimatch.mockReturnValueOnce({ match } as unknown as IMinimatch);
+      MinimatchMock.mockReturnValueOnce({ match } as unknown as IMinimatch);
 
       const  filter = New("foo/*");
 
@@ -31,7 +31,7 @@ describe("filters/glob.ts", () => {
       const query = "foobar.svg";
 
       const match = jest.fn().mockReturnValue(false);
-      Minimatch.mockReturnValueOnce({ match } as unknown as IMinimatch);
+      MinimatchMock.mockReturnValueOnce({ match } as unknown as IMinimatch);
 
       const  filter = New("foo/*");
 

--- a/test/unit/filters/glob.test.ts
+++ b/test/unit/filters/glob.test.ts
@@ -1,14 +1,12 @@
 import type { IMinimatch } from "minimatch";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("minimatch");
 
 import * as minimatch from "minimatch";
 
 import New from "../../../src/filters/glob";
 
-const Minimatch = mocked(minimatch.Minimatch);
+const Minimatch = minimatch.Minimatch as jest.MockedClass<typeof minimatch.Minimatch>; // eslint-disable-line max-len
 
 describe("filters/glob.ts", () => {
   describe("::New", () => {

--- a/test/unit/filters/index.test.ts
+++ b/test/unit/filters/index.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/github");
 jest.mock("../../../src/clients");
 jest.mock("../../../src/filters/pr-files");
@@ -10,14 +8,14 @@ import * as github from "@actions/github";
 
 import clients from "../../../src/clients/index";
 import filters from "../../../src/filters/index";
-import _NewPrFilesFilter from "../../../src/filters/pr-files";
-import _NewPushedFilesFilter from "../../../src/filters/pushed-files";
-import _NewSvgsFilter from "../../../src/filters/svgs";
+import NewPrFilesFilter from "../../../src/filters/pr-files";
+import NewPushedFilesFilter from "../../../src/filters/pushed-files";
+import NewSvgsFilter from "../../../src/filters/svgs";
 import inp from "../../__common__/inputter.mock";
 
-const NewPrFilesFilter = mocked(_NewPrFilesFilter);
-const NewPushedFilesFilter = mocked(_NewPushedFilesFilter);
-const NewSvgsFilter = mocked(_NewSvgsFilter);
+const NewPrFilesFilterMock = NewPrFilesFilter as jest.MockedFunction<typeof NewPrFilesFilter>; // eslint-disable-line max-len
+const NewPushedFilesFilterMock = NewPushedFilesFilter as jest.MockedFunction<typeof NewPushedFilesFilter>; // eslint-disable-line max-len
+const NewSvgsFilterMock = NewSvgsFilter as jest.MockedFunction<typeof NewSvgsFilter>; // eslint-disable-line max-len
 
 describe("filters/index.ts", () => {
   let client;
@@ -40,9 +38,9 @@ describe("filters/index.ts", () => {
   });
 
   beforeEach(() => {
-    NewPrFilesFilter.mockClear();
-    NewPushedFilesFilter.mockClear();
-    NewSvgsFilter.mockClear();
+    NewPrFilesFilterMock.mockClear();
+    NewPushedFilesFilterMock.mockClear();
+    NewSvgsFilterMock.mockClear();
   });
 
   test("create Pull Request files filter", async () => {

--- a/test/unit/helpers/deprecation.test.ts
+++ b/test/unit/helpers/deprecation.test.ts
@@ -8,10 +8,10 @@ import {
   deprecationWarnings,
 } from "../../../src/helpers/deprecation";
 
+const coreWarning = core.warning as jest.MockedFunction<typeof core.warning>;
+
 describe("helpers/deprecation.ts", () => {
   beforeEach(() => {
-    const coreWarning = core.warning as jest.MockedFunction<typeof core.warning>; // eslint-disable-line max-len
-
     coreWarning.mockClear();
   });
 

--- a/test/unit/helpers/deprecation.test.ts
+++ b/test/unit/helpers/deprecation.test.ts
@@ -1,12 +1,8 @@
 import type { SupportedSvgoVersions } from "../../../src/svgo";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/core");
 
-import * as _core from "@actions/core";
-
-const core = mocked(_core);
+import * as core from "@actions/core";
 
 import {
   deprecationWarnings,
@@ -14,7 +10,9 @@ import {
 
 describe("helpers/deprecation.ts", () => {
   beforeEach(() => {
-    core.warning.mockClear();
+    const coreWarning = core.warning as jest.MockedFunction<typeof core.warning>; // eslint-disable-line max-len
+
+    coreWarning.mockClear();
   });
 
   test.each([

--- a/test/unit/helpers/filters.test.ts
+++ b/test/unit/helpers/filters.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/github");
 jest.mock("../../../src/clients");
 jest.mock("../../../src/errors");
@@ -9,13 +7,16 @@ import * as github from "@actions/github";
 
 import clients from "../../../src/clients";
 import errors from "../../../src/errors";
-import _filters from "../../../src/filters";
+import filters from "../../../src/filters";
 import {
   getFilters,
 } from "../../../src/helpers/filters";
 import inp from "../../__common__/inputter.mock";
 
-const filters = mocked(_filters);
+const filtersNewGlobFilter = filters.NewGlobFilter as jest.MockedFunction<typeof filters.NewGlobFilter>; // eslint-disable-line max-len
+const filtersNewSvgsFilter = filters.NewSvgsFilter as jest.MockedFunction<typeof filters.NewSvgsFilter>; // eslint-disable-line max-len
+const filtersNewPrFilesFilter = filters.NewPrFilesFilter as jest.MockedFunction<typeof filters.NewPrFilesFilter>; // eslint-disable-line max-len
+const filtersNewPushedFilesFilter = filters.NewPushedFilesFilter as jest.MockedFunction<typeof filters.NewPushedFilesFilter>; // eslint-disable-line max-len
 
 describe("helpers/filters.ts", () => {
   describe("::getFilters", () => {
@@ -28,10 +29,10 @@ describe("helpers/filters.ts", () => {
     });
 
     beforeEach(() => {
-      filters.NewGlobFilter.mockClear();
-      filters.NewSvgsFilter.mockClear();
-      filters.NewPrFilesFilter.mockClear();
-      filters.NewPushedFilesFilter.mockClear();
+      filtersNewGlobFilter.mockClear();
+      filtersNewSvgsFilter.mockClear();
+      filtersNewPrFilesFilter.mockClear();
+      filtersNewPushedFilesFilter.mockClear();
     });
 
     beforeEach(() => {
@@ -51,7 +52,7 @@ describe("helpers/filters.ts", () => {
         config.ignoreGlobs.value = [];
 
         const globFilter = jest.fn();
-        filters.NewGlobFilter.mockReturnValue(globFilter);
+        filtersNewGlobFilter.mockReturnValue(globFilter);
 
         const [, err] = await getFilters({ client, config, github });
         expect(err).toBeNull();
@@ -62,7 +63,7 @@ describe("helpers/filters.ts", () => {
         config.ignoreGlobs.value = ["foobar/**"];
 
         const globFilter = jest.fn();
-        filters.NewGlobFilter.mockReturnValue(globFilter);
+        filtersNewGlobFilter.mockReturnValue(globFilter);
 
         const [result, err] = await getFilters({ client, config, github });
         expect(err).toBeNull();
@@ -78,8 +79,8 @@ describe("helpers/filters.ts", () => {
 
         const globFilter1 = jest.fn();
         const globFilter2 = jest.fn();
-        filters.NewGlobFilter.mockReturnValueOnce(globFilter1);
-        filters.NewGlobFilter.mockReturnValueOnce(globFilter2);
+        filtersNewGlobFilter.mockReturnValueOnce(globFilter1);
+        filtersNewGlobFilter.mockReturnValueOnce(globFilter2);
 
         const [result, err] = await getFilters({ client, config, github });
         expect(err).toBeNull();
@@ -94,7 +95,7 @@ describe("helpers/filters.ts", () => {
       github.context.eventName = "foobar";
 
       const svgsFilter = jest.fn();
-      filters.NewSvgsFilter.mockReturnValue(svgsFilter);
+      filtersNewSvgsFilter.mockReturnValue(svgsFilter);
 
       const [result, err] = await getFilters({ client, config, github });
       expect(err).toBeNull();
@@ -108,7 +109,7 @@ describe("helpers/filters.ts", () => {
         github.context.eventName = "pull_request";
 
         const prFilesFilter = jest.fn();
-        filters.NewPrFilesFilter.mockResolvedValue([prFilesFilter, null]);
+        filtersNewPrFilesFilter.mockResolvedValue([prFilesFilter, null]);
 
         const [result, err] = await getFilters({ client, config, github });
         expect(err).toBeNull();
@@ -122,7 +123,7 @@ describe("helpers/filters.ts", () => {
         const error = errors.New("could not get Pull Request");
 
         const prFilesFilter = jest.fn();
-        filters.NewPrFilesFilter.mockResolvedValue([prFilesFilter, error]);
+        filtersNewPrFilesFilter.mockResolvedValue([prFilesFilter, error]);
 
         const [, err] = await getFilters({ client, config, github });
         expect(err).not.toBeNull();
@@ -145,7 +146,7 @@ describe("helpers/filters.ts", () => {
         github.context.eventName = "push";
 
         const pushFilesFilter = jest.fn();
-        filters.NewPushedFilesFilter.mockResolvedValue([
+        filtersNewPushedFilesFilter.mockResolvedValue([
           pushFilesFilter,
           null,
         ]);
@@ -162,7 +163,7 @@ describe("helpers/filters.ts", () => {
         const error = errors.New("could not get commits");
 
         const pushFilesFilter = jest.fn();
-        filters.NewPushedFilesFilter.mockResolvedValue([
+        filtersNewPushedFilesFilter.mockResolvedValue([
           pushFilesFilter,
           error,
         ]);

--- a/test/unit/helpers/svgo-config.test.ts
+++ b/test/unit/helpers/svgo-config.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("../../../src/errors");
 jest.mock("../../../src/parsers");
 
@@ -7,9 +5,10 @@ import errors from "../../../src/errors";
 import {
   parseRawSvgoConfig,
 } from "../../../src/helpers/svgo-config";
-import _parsers from "../../../src/parsers";
+import parsers from "../../../src/parsers";
 
-const parsers = mocked(_parsers);
+const parsersNewYaml = parsers.NewYaml as jest.MockedFunction<typeof parsers.NewYaml>; // eslint-disable-line max-len
+const parsersNewJavaScript = parsers.NewJavaScript as jest.MockedFunction<typeof parsers.NewJavaScript>; // eslint-disable-line max-len
 
 describe("helpers/svgo-config.ts", () => {
   describe("::parseRawSvgoConfig", () => {
@@ -41,7 +40,7 @@ describe("helpers/svgo-config.ts", () => {
       ];
 
       beforeEach(() => {
-        parsers.NewYaml.mockClear();
+        parsersNewYaml.mockClear();
       });
 
       test.each(svgoConfigPaths)("parse success (%s)", (svgoConfigPath) => {
@@ -49,7 +48,7 @@ describe("helpers/svgo-config.ts", () => {
           svgoConfigPath: { value: svgoConfigPath },
         });
 
-        parsers.NewYaml.mockReturnValue(successParser);
+        parsersNewYaml.mockReturnValue(successParser);
 
         const [result, err] = parseRawSvgoConfig({ config, rawConfig });
         expect(err).toBeNull();
@@ -64,7 +63,7 @@ describe("helpers/svgo-config.ts", () => {
           svgoConfigPath: { value: svgoConfigPath },
         });
 
-        parsers.NewYaml.mockReturnValue(errorParser);
+        parsersNewYaml.mockReturnValue(errorParser);
 
         const [, err] = parseRawSvgoConfig({ config, rawConfig });
         expect(err).not.toBeNull();
@@ -81,7 +80,7 @@ describe("helpers/svgo-config.ts", () => {
       ];
 
       beforeEach(() => {
-        parsers.NewJavaScript.mockClear();
+        parsersNewJavaScript.mockClear();
       });
 
       test.each(svgoConfigPaths)("parse success (%s)", (svgoConfigPath) => {
@@ -89,7 +88,7 @@ describe("helpers/svgo-config.ts", () => {
           svgoConfigPath: { value: svgoConfigPath },
         });
 
-        parsers.NewJavaScript.mockReturnValue(successParser);
+        parsersNewJavaScript.mockReturnValue(successParser);
 
         const [result, err] = parseRawSvgoConfig({ config, rawConfig });
         expect(err).toBeNull();
@@ -104,7 +103,7 @@ describe("helpers/svgo-config.ts", () => {
           svgoConfigPath: { value: svgoConfigPath },
         });
 
-        parsers.NewJavaScript.mockReturnValue(errorParser);
+        parsersNewJavaScript.mockReturnValue(errorParser);
 
         const [, err] = parseRawSvgoConfig({ config, rawConfig });
         expect(err).not.toBeNull();

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("@actions/core");
 jest.mock("@actions/github");
 jest.mock("../../src/main");
@@ -7,10 +5,8 @@ jest.mock("../../src/main");
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 
-import _main from  "../../src/main";
+import main from  "../../src/main";
 import "../../src/index"; // eslint-disable-line import/order
-
-const main = mocked(_main);
 
 describe("index.ts", () => {
   test("action initialization", () => {

--- a/test/unit/inputs/index.test.ts
+++ b/test/unit/inputs/index.test.ts
@@ -1,19 +1,21 @@
 import type { SupportedSvgoVersions } from "../../../src/svgo";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("../../../src/errors");
 jest.mock("../../../src/inputs/getters");
 jest.mock("../../../src/inputs/helpers");
 
 import errors from "../../../src/errors";
-import * as _getters from "../../../src/inputs/getters";
-import * as _helpers from "../../../src/inputs/helpers";
+import * as getters from "../../../src/inputs/getters";
+import * as helpers from "../../../src/inputs/helpers";
 import inputs from "../../../src/inputs/index";
 import inp from "../../__common__/inputter.mock";
 
-const getters = mocked(_getters);
-const helpers = mocked(_helpers);
+const gettersGetIgnoreGlobs = getters.getIgnoreGlobs as jest.MockedFunction<typeof getters.getIgnoreGlobs>; // eslint-disable-line max-len
+const gettersGetIsDryRun = getters.getIsDryRun as jest.MockedFunction<typeof getters.getIsDryRun>; // eslint-disable-line max-len
+const gettersGetIsStrictMode = getters.getIsStrictMode as jest.MockedFunction<typeof getters.getIsStrictMode>; // eslint-disable-line max-len
+const gettersGetSvgoConfigPath = getters.getSvgoConfigPath as jest.MockedFunction<typeof getters.getSvgoConfigPath>; // eslint-disable-line max-len
+const gettersGetSvgoVersion = getters.getSvgoVersion as jest.MockedFunction<typeof getters.getSvgoVersion>; // eslint-disable-line max-len
+const helpersGetDefaultSvgoConfigPath = helpers.getDefaultSvgoConfigPath as jest.MockedFunction<typeof helpers.getDefaultSvgoConfigPath>; // eslint-disable-line max-len
 
 describe("inputs/index.ts", () => {
   describe("::New", () => {
@@ -37,7 +39,7 @@ describe("inputs/index.ts", () => {
       test("can get value", () => {
         const configuredValues = ["foobar"];
 
-        getters.getIgnoreGlobs.mockReturnValueOnce([
+        gettersGetIgnoreGlobs.mockReturnValueOnce([
           { provided, value: configuredValues },
           null,
         ]);
@@ -51,7 +53,7 @@ describe("inputs/index.ts", () => {
       test("can't get value", () => {
         const errorMsg = "couldn't get ignoreGlob";
 
-        getters.getIgnoreGlobs.mockReturnValueOnce([
+        gettersGetIgnoreGlobs.mockReturnValueOnce([
           { provided, value: [] },
           errors.New(errorMsg),
         ]);
@@ -78,7 +80,7 @@ describe("inputs/index.ts", () => {
       test("can get value", () => {
         const configuredValue = false;
 
-        getters.getIsDryRun.mockReturnValueOnce([
+        gettersGetIsDryRun.mockReturnValueOnce([
           { provided, value: configuredValue },
           null,
         ]);
@@ -92,7 +94,7 @@ describe("inputs/index.ts", () => {
       test("can't get value", () => {
         const errorMsg = "couldn't get dry-run";
 
-        getters.getIsDryRun.mockReturnValueOnce([
+        gettersGetIsDryRun.mockReturnValueOnce([
           { provided, value: true },
           errors.New(errorMsg),
         ]);
@@ -119,7 +121,7 @@ describe("inputs/index.ts", () => {
       test("can get value", () => {
         const configuredValue = false;
 
-        getters.getIsStrictMode.mockReturnValueOnce([
+        gettersGetIsStrictMode.mockReturnValueOnce([
           { provided, value: configuredValue },
           null,
         ]);
@@ -133,7 +135,7 @@ describe("inputs/index.ts", () => {
       test("can't get value", () => {
         const errorMsg = "couldn't get strict";
 
-        getters.getIsStrictMode.mockReturnValueOnce([
+        gettersGetIsStrictMode.mockReturnValueOnce([
           { provided, value: true },
           errors.New(errorMsg),
         ]);
@@ -158,13 +160,13 @@ describe("inputs/index.ts", () => {
 
     describe("svgoConfigPath", () => {
       beforeEach(() => {
-        getters.getSvgoConfigPath.mockClear();
+        gettersGetSvgoConfigPath.mockClear();
       });
 
       test("can get value", () => {
         const configuredValue = "foobar";
 
-        getters.getSvgoConfigPath.mockReturnValueOnce([
+        gettersGetSvgoConfigPath.mockReturnValueOnce([
           { provided, value: configuredValue },
           null,
         ]);
@@ -178,7 +180,7 @@ describe("inputs/index.ts", () => {
       test("can't get value", () => {
         const errorMsg = "couldn't get svgo-config";
 
-        getters.getSvgoConfigPath.mockReturnValueOnce([
+        gettersGetSvgoConfigPath.mockReturnValueOnce([
           { provided, value: "" },
           errors.New(errorMsg),
         ]);
@@ -195,11 +197,11 @@ describe("inputs/index.ts", () => {
         ["1", ".svgo.yml"],
         ["2", "svgo.config.js"],
       ])("default value", (svgoVersion, svgoConfigPath) => {
-        getters.getSvgoVersion.mockReturnValueOnce([
+        gettersGetSvgoVersion.mockReturnValueOnce([
           { provided, value: svgoVersion as SupportedSvgoVersions },
           null,
         ]);
-        helpers.getDefaultSvgoConfigPath.mockReturnValueOnce(svgoConfigPath);
+        helpersGetDefaultSvgoConfigPath.mockReturnValueOnce(svgoConfigPath);
 
         const [, err] = inputs.New({ inp });
 
@@ -218,7 +220,7 @@ describe("inputs/index.ts", () => {
       test("can get value", () => {
         const configuredValue =  "2";
 
-        getters.getSvgoVersion.mockReturnValueOnce([
+        gettersGetSvgoVersion.mockReturnValueOnce([
           { provided, value: configuredValue },
           null,
         ]);
@@ -232,7 +234,7 @@ describe("inputs/index.ts", () => {
       test("can't get value", () => {
         const errorMsg = "couldn't get svgo-version";
 
-        getters.getSvgoVersion.mockReturnValueOnce([
+        gettersGetSvgoVersion.mockReturnValueOnce([
           { provided, value: "2" },
           errors.New(errorMsg),
         ]);

--- a/test/unit/optimize/index.test.ts
+++ b/test/unit/optimize/index.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("../../../src/errors");
 jest.mock("../../../src/file-systems");
 jest.mock("../../../src/optimize/optimize");
@@ -10,13 +8,13 @@ import errors from "../../../src/errors";
 import fileSystems from "../../../src/file-systems";
 import optimize from "../../../src/optimize/index";
 import * as _optimize from "../../../src/optimize/optimize";
-import * as _read from "../../../src/optimize/read";
-import * as _write from "../../../src/optimize/write";
+import * as read from "../../../src/optimize/read";
+import * as write from "../../../src/optimize/write";
 import optimizer from "../../__common__/optimizer.mock";
 
-const optimizeAll = mocked(_optimize.optimizeAll);
-const readFiles = mocked(_read.readFiles);
-const writeFiles = mocked(_write.writeFiles);
+const optimizeAll = _optimize.optimizeAll as jest.MockedFunction<typeof _optimize.optimizeAll>; // eslint-disable-line max-len
+const readFiles = read.readFiles as jest.MockedFunction<typeof read.readFiles>;
+const writeFiles = write.writeFiles as jest.MockedFunction<typeof write.writeFiles>;// eslint-disable-line max-len
 
 describe("optimize/index.ts", () => {
   describe("::Files", () => {

--- a/test/unit/outputs/index.test.ts
+++ b/test/unit/outputs/index.test.ts
@@ -1,7 +1,5 @@
 import type { OutputName } from "../../../src/outputs/names";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("../../../src/errors");
 jest.mock("../../../src/outputs/names");
 jest.mock("../../../src/outputs/values");
@@ -9,14 +7,14 @@ jest.mock("../../../src/outputs/write");
 
 import errors from "../../../src/errors";
 import outputs from "../../../src/outputs/index";
-import * as _names from "../../../src/outputs/names";
-import * as _values from "../../../src/outputs/values";
-import * as _write from "../../../src/outputs/write";
+import * as names from "../../../src/outputs/names";
+import * as values from "../../../src/outputs/values";
+import * as write from "../../../src/outputs/write";
 import out from "../../__common__/outputter.mock";
 
-const getOutputNamesFor = mocked(_names.getOutputNamesFor);
-const getValuesForOutputs = mocked(_values.getValuesForOutputs);
-const writeOutputs = mocked(_write.writeOutputs);
+const getOutputNamesFor = names.getOutputNamesFor as jest.MockedFunction<typeof names.getOutputNamesFor>; // eslint-disable-line max-len
+const getValuesForOutputs = values.getValuesForOutputs as jest.MockedFunction<typeof values.getValuesForOutputs>; // eslint-disable-line max-len
+const writeOutputs = write.writeOutputs as jest.MockedFunction<typeof write.writeOutputs>; // eslint-disable-line max-len
 
 describe("outputs/index.js", () => {
   const data = {

--- a/test/unit/parsers/index.test.ts
+++ b/test/unit/parsers/index.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("js-yaml");
 jest.mock("node-eval");
 jest.mock("../../../src/parsers/builder");
@@ -10,7 +8,7 @@ import nodeEval from "node-eval";
 import * as builder from "../../../src/parsers/builder";
 import parsers from "../../../src/parsers/index";
 
-const buildSafeParser = mocked(builder.buildSafeParser, true);
+const buildSafeParser = builder.buildSafeParser as jest.MockedFunction<typeof builder.buildSafeParser>; // eslint-disable-line max-len
 
 describe("parsers/index.js", () => {
   beforeEach(() => {

--- a/test/unit/svgo/index.test.ts
+++ b/test/unit/svgo/index.test.ts
@@ -1,7 +1,5 @@
 import type { SupportedSvgoVersions } from "../../../src/svgo";
 
-import { mocked } from "ts-jest/utils";
-
 jest.mock("../../../src/errors");
 jest.mock("../../../src/svgo/project");
 jest.mock("../../../src/svgo/v1");
@@ -9,13 +7,13 @@ jest.mock("../../../src/svgo/v2");
 
 import errors from "../../../src/errors";
 import svgo from "../../../src/svgo/index";
-import _project from "../../../src/svgo/project";
-import _svgoV1 from "../../../src/svgo/v1";
-import _svgoV2 from "../../../src/svgo/v2";
+import _createSvgoOptimizerForProject from "../../../src/svgo/project";
+import svgoV1 from "../../../src/svgo/v1";
+import svgoV2 from "../../../src/svgo/v2";
 
-const createSvgoOptimizerForProject = mocked(_project);
-const svgoV1 = mocked(_svgoV1);
-const svgoV2 = mocked(_svgoV2);
+const createSvgoOptimizerForProject = _createSvgoOptimizerForProject as jest.MockedFunction<typeof _createSvgoOptimizerForProject>; // eslint-disable-line max-len
+const svgoV1New = svgoV1.New as jest.MockedFunction<typeof svgoV1.New>;
+const svgoV2New = svgoV2.New as jest.MockedFunction<typeof svgoV2.New>;
 
 describe("svgo/index.ts", () => {
   describe("::New", () => {
@@ -24,8 +22,8 @@ describe("svgo/index.ts", () => {
     };
 
     beforeEach(() => {
-      svgoV1.New.mockClear();
-      svgoV2.New.mockClear();
+      svgoV1New.mockClear();
+      svgoV2New.mockClear();
     });
 
     test("version 1", () => {

--- a/test/unit/svgo/project.test.ts
+++ b/test/unit/svgo/project.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("import-cwd");
 jest.mock("../../../src/errors");
 jest.mock("../../../src/svgo/v1");
@@ -8,12 +6,12 @@ jest.mock("../../../src/svgo/v2");
 import importCwd from "import-cwd";
 
 import createSvgoOptimizerForProject from "../../../src/svgo/project";
-import _svgoV1 from "../../../src/svgo/v1";
-import _svgoV2 from "../../../src/svgo/v2";
+import svgoV1 from "../../../src/svgo/v1";
+import svgoV2 from "../../../src/svgo/v2";
 
-const importCwdSilent = mocked(importCwd.silent);
-const svgoV1 = mocked(_svgoV1);
-const svgoV2 = mocked(_svgoV2);
+const importCwdSilent = importCwd.silent as jest.MockedFunction<typeof importCwd.silent>; // eslint-disable-line max-len
+const svgoV1New = svgoV1.New as jest.MockedFunction<typeof svgoV1.New>;
+const svgoV2New = svgoV2.New as jest.MockedFunction<typeof svgoV2.New>;
 
 describe("svgo/project.ts", () => {
   describe("::New", () => {
@@ -27,8 +25,8 @@ describe("svgo/project.ts", () => {
     beforeEach(() => {
       importCwdSilent.mockReset();
 
-      svgoV1.New.mockClear();
-      svgoV2.New.mockClear();
+      svgoV1New.mockClear();
+      svgoV2New.mockClear();
     });
 
     test("tries to import 'svgo'", () => {

--- a/test/unit/svgo/v1/index.test.ts
+++ b/test/unit/svgo/v1/index.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("svgo-v1");
 jest.mock("../../../../src/errors");
 jest.mock("../../../../src/svgo/v1/wrapper");
@@ -7,16 +5,16 @@ jest.mock("../../../../src/svgo/v1/wrapper");
 import svgo from "svgo-v1";
 
 import svgoV1 from "../../../../src/svgo/v1/index";
-import _SvgoV1Wrapper from "../../../../src/svgo/v1/wrapper";
+import SvgoV1Wrapper from "../../../../src/svgo/v1/wrapper";
 
-const SvgoV1Wrapper = mocked(_SvgoV1Wrapper);
+const SvgoV1WrapperMock = SvgoV1Wrapper as jest.MockedClass<typeof SvgoV1Wrapper>; // eslint-disable-line max-len
 
 describe("svgo/v1/index.ts", () => {
-  describe("::New", () => {
-    beforeEach(() => {
-      SvgoV1Wrapper.mockClear();
-    });
+  beforeEach(() => {
+    SvgoV1WrapperMock.mockClear();
+  });
 
+  describe("::New", () => {
     test("create instance successfully with configuration", async () => {
       const options = { foo: "bar" };
 
@@ -29,10 +27,6 @@ describe("svgo/v1/index.ts", () => {
 
   describe("::NewFrom", () => {
     const importedSvgo = { hello: "world" };
-
-    beforeEach(() => {
-      SvgoV1Wrapper.mockClear();
-    });
 
     test("create instance successfully with configuration", async () => {
       const options = { foo: "bar" };

--- a/test/unit/svgo/v2/index.test.ts
+++ b/test/unit/svgo/v2/index.test.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 jest.mock("svgo-v2");
 jest.mock("../../../../src/errors");
 jest.mock("../../../../src/svgo/v2/wrapper");
@@ -7,16 +5,16 @@ jest.mock("../../../../src/svgo/v2/wrapper");
 import svgo from "svgo-v2"; // eslint-disable-line import/default
 
 import svgoV2 from "../../../../src/svgo/v2/index";
-import _SvgoV2Wrapper from "../../../../src/svgo/v2/wrapper";
+import SvgoV2Wrapper from "../../../../src/svgo/v2/wrapper";
 
-const SvgoV2Wrapper = mocked(_SvgoV2Wrapper);
+const SvgoV2WrapperMock = SvgoV2Wrapper as jest.MockedClass<typeof SvgoV2Wrapper>; // eslint-disable-line max-len
 
 describe("svgo/v2/index.ts", () => {
-  describe("::New", () => {
-    beforeEach(() => {
-      SvgoV2Wrapper.mockClear();
-    });
+  beforeEach(() => {
+    SvgoV2WrapperMock.mockClear();
+  });
 
+  describe("::New", () => {
     test("create instance successfully with configuration", async () => {
       const options = { foo: "bar" };
 
@@ -29,10 +27,6 @@ describe("svgo/v2/index.ts", () => {
 
   describe("::NewFrom", () => {
     const importedSvgo = { hello: "world" };
-
-    beforeEach(() => {
-      SvgoV2Wrapper.mockClear();
-    });
 
     test("create instance successfully with configuration", async () => {
       const options = { foo: "bar" };


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

Update the tests to move away from [ts-jest](https://www.npmjs.com/package/ts-jest)'s `mocked` utility function. As an added bonus, this refactoring also uncovered some (1) unused mocks and (2) redundant test setup hooks.
