### PR TITLE
Add Stryker Dashboard link to the Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,8 @@ We make use of [Mutation Testing] to improve the quality of unit tests. We use
 the mutation testing framework [StrykerJS]. By default the mutation tests run on
 all the source code using all the unit tests. After running the mutation tests,
 a mutation report is available in HTML format at `_reports/mutation/index.html`.
+Alternatively, you can find a report for the `main` branch online as a [Stryker
+Dashboard].
 
 You can change the mutation test configuration (in `stryker.config.js`) to focus
 on a subset of the source code or unit tests (we ask that you don't commit such
@@ -238,3 +240,4 @@ change the Stryker configuration as follows.
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new/choose
 [sinon]: https://sinonjs.org/
 [strykerjs]: https://stryker-mutator.io/
+[stryker dashboard]: https://dashboard.stryker-mutator.io/reports/github.com/ericcornelissen/svgo-action/main


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

Simply add a link to the Stryker Dashboard in the Contributing Guidelines. This should help with visibility (it's not obvious the badge also links there), and may nudge potential contributors to check it out (and improve testing when the score isn't 100%).
