### PR TITLE
Fix inputs documentation with regards to SVGO v1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ### Breaking changes
 
-- Drop **built-in** support for SVGO v1. ([#521])
+- Drop **built-in** support for SVGO v1. ([#521], [#535])
 - Update Node.js runtime to v16. ([#526])
 
 ### Changes
@@ -397,5 +397,6 @@ Versioning].
 [#521]: https://github.com/ericcornelissen/svgo-action/pull/521
 [#526]: https://github.com/ericcornelissen/svgo-action/pull/526
 [#532]: https://github.com/ericcornelissen/svgo-action/pull/532
+[#535]: https://github.com/ericcornelissen/svgo-action/pull/535
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -188,13 +188,12 @@ To use an SVGO config file in a folder:
 | `svgo-version` | `2`           |
 
 The `svgo-version` input allows you to specify the version of [SVGO] that you
-want to use. This can be either `1` for the latest v1 release, `2` for the
-latest v2 release, or the string `"project"` for the version of SVGO installed
-for your project.
+want to use. This can be either `2` for the latest v2 release, or the string
+`"project"` for the version of SVGO installed for your project. For `"project"`
+both SVGO v1 and v2 are supported.
 
 > :warning: SVGO v1 has been deprecated, we strongly recommend upgrading to
-> SVGO v2. For more information see the [SVGO v2 release notes]. Support for
-> SVGO v1 **will** be dropped in the next major release of this Action.
+> SVGO v2. For more information see the [SVGO v2 release notes].
 
 ### Examples
 
@@ -208,17 +207,6 @@ To use the SVGO version used by your project:
 - uses: ericcornelissen/svgo-action@v2
   with:
     svgo-version: project
-```
-
-To change the SVGO major version to v1.x.x (note that the default `svgo-config`
-will be `".svgo.yml"`):
-
-```yaml
-# .github/workflows/optimize.yml
-
-- uses: ericcornelissen/svgo-action@v2
-  with:
-    svgo-version: 1
 ```
 
 [`on: pull_request`]: ./events.md#on-pull_request

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -154,9 +154,6 @@ for [SVGO]. The configuration file must be a JavaScript or a [YAML] file. If the
 specified file is not found the Action will fall back on SVGO's default
 configuration.
 
-> :information_source: If `svgo-version` is configured to `1` the default value
-> of `svgo-config` changes to `".svgo.yml"`.
-
 ### Examples
 
 To use an SVGO config file with a non-standard name:
@@ -177,6 +174,16 @@ To use an SVGO config file in a folder:
 - uses: ericcornelissen/svgo-action@v2
   with:
     svgo-config: path/to/svgo.config.js
+```
+
+To use an SVGO config file in the YAML format (e.g. if you're using SVGO v1):
+
+```yaml
+# .github/workflows/optimize.yml
+
+- uses: ericcornelissen/svgo-action@v2
+  with:
+    svgo-config: .svgo.yml
 ```
 
 ---


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [n/a] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Update the documentation for the `svgo-version` and `svgo-config` inputs with regards to having dropped built-in SVGO v1 support in v3 of the Action.
