### PR TITLE
Replace node-eval by eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Replace dependency `node-eval` by `eval`. ([#536])
 
 ## [3.0.0] - 2022-03-31
 
@@ -414,5 +414,6 @@ Versioning].
 [#526]: https://github.com/ericcornelissen/svgo-action/pull/526
 [#532]: https://github.com/ericcornelissen/svgo-action/pull/532
 [#535]: https://github.com/ericcornelissen/svgo-action/pull/535
+[#536]: https://github.com/ericcornelissen/svgo-action/pull/536
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/__mocks__/eval.ts
+++ b/__mocks__/eval.ts
@@ -1,4 +1,4 @@
-const nodeEval = jest.fn()
+const _eval = jest.fn()
   .mockName("eval::default");
 
-export default nodeEval;
+export default _eval;

--- a/__mocks__/eval.ts
+++ b/__mocks__/eval.ts
@@ -1,4 +1,4 @@
 const nodeEval = jest.fn()
-  .mockName("node-eval::default");
+  .mockName("eval::default");
 
 export default nodeEval;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@actions/core": "1.6.0",
         "@actions/github": "5.0.0",
+        "eval": "0.1.8",
         "import-cwd": "3.0.0",
         "js-yaml": "4.1.0",
         "minimatch": "5.0.1",
@@ -2738,8 +2739,7 @@
     "node_modules/@types/node": {
       "version": "16.11.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-      "dev": true
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -5077,6 +5077,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eval": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.8.tgz",
+      "integrity": "sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==",
+      "dependencies": {
+        "@types/node": "*",
+        "require-like": ">= 0.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/execa": {
@@ -9753,6 +9765,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-like": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
+      "integrity": "sha1-rW8wwTvs15cBDEaK+ndcDAprR/o=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -13478,8 +13498,7 @@
     "@types/node": {
       "version": "16.11.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-      "dev": true
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -15204,6 +15223,15 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "eval": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.8.tgz",
+      "integrity": "sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==",
+      "requires": {
+        "@types/node": "*",
+        "require-like": ">= 0.1.1"
+      }
     },
     "execa": {
       "version": "5.1.1",
@@ -18676,6 +18704,11 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
+    },
+    "require-like": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
+      "integrity": "sha1-rW8wwTvs15cBDEaK+ndcDAprR/o="
     },
     "resolve": {
       "version": "1.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "import-cwd": "3.0.0",
         "js-yaml": "4.1.0",
         "minimatch": "5.0.1",
-        "node-eval": "2.0.0",
         "svgo-v2": "npm:svgo@2.8.0"
       },
       "devDependencies": {
@@ -8968,17 +8967,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node_modules/node-eval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-eval/-/node-eval-2.0.0.tgz",
-      "integrity": "sha512-Ap+L9HznXAVeJj3TJ1op6M6bg5xtTq8L5CU/PJxtkhea/DrIxdTknGKIECKd/v/Lgql95iuMAYvIzBNd0pmcMg==",
-      "dependencies": {
-        "path-is-absolute": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -9389,6 +9377,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18126,14 +18115,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-eval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-eval/-/node-eval-2.0.0.tgz",
-      "integrity": "sha512-Ap+L9HznXAVeJj3TJ1op6M6bg5xtTq8L5CU/PJxtkhea/DrIxdTknGKIECKd/v/Lgql95iuMAYvIzBNd0pmcMg==",
-      "requires": {
-        "path-is-absolute": "1.0.1"
-      }
-    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -18442,7 +18423,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "import-cwd": "3.0.0",
     "js-yaml": "4.1.0",
     "minimatch": "5.0.1",
-    "node-eval": "2.0.0",
     "svgo-v2": "npm:svgo@2.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@actions/core": "1.6.0",
     "@actions/github": "5.0.0",
+    "eval": "0.1.8",
     "import-cwd": "3.0.0",
     "js-yaml": "4.1.0",
     "minimatch": "5.0.1",

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,7 +1,7 @@
 import type { SafeParseFn } from "./types";
 
 import * as yaml from "js-yaml";
-import nodeEval from "node-eval";
+import nodeEval from "eval";
 
 import { buildSafeParser } from "./builder";
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,12 +1,12 @@
 import type { SafeParseFn } from "./types";
 
+import jsEval from "eval";
 import * as yaml from "js-yaml";
-import nodeEval from "eval";
 
 import { buildSafeParser } from "./builder";
 
 function NewJavaScript(): SafeParseFn<unknown> {
-  return buildSafeParser(nodeEval);
+  return buildSafeParser(jsEval);
 }
 
 function NewYaml(): SafeParseFn<unknown> {

--- a/test/integration/helpers.test.ts
+++ b/test/integration/helpers.test.ts
@@ -1,8 +1,8 @@
 import type { Octokit } from "../../src/types";
 
+jest.dontMock("eval");
 jest.dontMock("js-yaml");
 jest.dontMock("minimatch");
-jest.dontMock("eval");
 
 jest.mock("@actions/core");
 jest.mock("@actions/github");

--- a/test/integration/helpers.test.ts
+++ b/test/integration/helpers.test.ts
@@ -2,7 +2,7 @@ import type { Octokit } from "../../src/types";
 
 jest.dontMock("js-yaml");
 jest.dontMock("minimatch");
-jest.dontMock("node-eval");
+jest.dontMock("eval");
 
 jest.mock("@actions/core");
 jest.mock("@actions/github");

--- a/test/integration/parsers.test.ts
+++ b/test/integration/parsers.test.ts
@@ -1,5 +1,5 @@
-jest.dontMock("js-yaml");
 jest.dontMock("eval");
+jest.dontMock("js-yaml");
 
 import parsers from "../../src/parsers";
 

--- a/test/integration/parsers.test.ts
+++ b/test/integration/parsers.test.ts
@@ -1,5 +1,5 @@
 jest.dontMock("js-yaml");
-jest.dontMock("node-eval");
+jest.dontMock("eval");
 
 import parsers from "../../src/parsers";
 

--- a/test/unit/parsers/index.test.ts
+++ b/test/unit/parsers/index.test.ts
@@ -1,9 +1,9 @@
 jest.mock("js-yaml");
-jest.mock("node-eval");
+jest.mock("eval");
 jest.mock("../../../src/parsers/builder");
 
 import * as yaml from "js-yaml";
-import nodeEval from "node-eval";
+import nodeEval from "eval";
 
 import * as builder from "../../../src/parsers/builder";
 import parsers from "../../../src/parsers/index";
@@ -16,7 +16,7 @@ describe("parsers/index.js", () => {
   });
 
   describe("::NewJavaScript", () => {
-    test("does use node-eval", () => {
+    test("does use eval", () => {
       parsers.NewJavaScript();
       expect(buildSafeParser).toHaveBeenCalledWith(nodeEval);
     });
@@ -33,7 +33,7 @@ describe("parsers/index.js", () => {
       expect(buildSafeParser).toHaveBeenCalledWith(yaml.load);
     });
 
-    test("does not use node-eval", () => {
+    test("does not use eval", () => {
       parsers.NewYaml();
       expect(buildSafeParser).not.toHaveBeenCalledWith(nodeEval);
     });

--- a/test/unit/parsers/index.test.ts
+++ b/test/unit/parsers/index.test.ts
@@ -1,9 +1,9 @@
-jest.mock("js-yaml");
 jest.mock("eval");
+jest.mock("js-yaml");
 jest.mock("../../../src/parsers/builder");
 
+import jsEval from "eval";
 import * as yaml from "js-yaml";
-import nodeEval from "eval";
 
 import * as builder from "../../../src/parsers/builder";
 import parsers from "../../../src/parsers/index";
@@ -18,7 +18,7 @@ describe("parsers/index.js", () => {
   describe("::NewJavaScript", () => {
     test("does use eval", () => {
       parsers.NewJavaScript();
-      expect(buildSafeParser).toHaveBeenCalledWith(nodeEval);
+      expect(buildSafeParser).toHaveBeenCalledWith(jsEval);
     });
 
     test("does not use js-yaml", () => {
@@ -35,7 +35,7 @@ describe("parsers/index.js", () => {
 
     test("does not use eval", () => {
       parsers.NewYaml();
-      expect(buildSafeParser).not.toHaveBeenCalledWith(nodeEval);
+      expect(buildSafeParser).not.toHaveBeenCalledWith(jsEval);
     });
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Replaces [`node-eval`] with [`eval`]. Why change? Primarily because [`node-eval`] was last updated 4 years ago[^1] and `eval` 7 days ago[^2] (at the time of writing), indicating that it is still actively maintained. Additionally, it's defaults are more secure[^3].

As of writing this, I'm not planning to backport this change to v2 - as far as I can tell there's nothing actually wrong with [`node-eval`]. That said, backporting this change to v2 should be relatively straightforword. I'd happily merge a PR if anyone wants to contribute by applying this change to [the `main-v2` branch](https://github.com/ericcornelissen/svgo-action/tree/main-v2).

[`eval`]: https://www.npmjs.com/package/eval
[`node-eval`]: https://www.npmjs.com/package/node-eval

[^1]: The last activity in the `node-eval` repository from the maintainer is also ~4 years ago.
[^2]: And before that 10 days ago, and before that 1 year ago (both at the time of writing). Additionally, I submitted a PR against the `eval` repository and it got accepted within two days.
[^3]: I started looking into this because I was wondering if anything was leaking into the context of the JavaScript evaluation