### PR TITLE
Prevent committing changes to `lib/` during normal development

### DIFF
--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -3,6 +3,12 @@
 . "$(dirname $0)/common.sh"
 
 if [ ! $(IS_MERGING) ]; then
+  LIB_STAGED_COUNT=$(git diff --name-only --staged lib/ | wc -l)
+  if [ "$LIB_STAGED_COUNT" -ne "0" ]; then
+    echo "[INFO] All changes to the lib/ directory have been unstaged. Changes in the lib/ directory should not be committed."
+    git restore --staged lib/
+  fi
+
   git stash push --quiet --include-untracked --keep-index
 fi
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [n/a] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

Prevent anyone from committing changes to the `lib/` directory directly through [the pre-commit hook](https://github.com/ericcornelissen/svgo-action/blob/f6cde792c043613360a44151b0345f9a21542e4c/script/hooks/pre-commit).

If the changes are omitted from the commit, this is communicated to the committer through an `echo` message.