### PR TITLE
Fix "Could not parse SVGO configuration" e2e test error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 ## [Unreleased]
 
 - Add example workflow for scheduled optimization Pull Requests. ([#544])
-- Replace dependency `node-eval` by `eval`. ([#536])
+- Replace dependency `node-eval` by `eval`. ([#536], [#551])
 - Update dependency `@actions/core`. ([#546])
 - Update dependency `@actions/github`. ([#537])
 
@@ -421,5 +421,6 @@ Versioning].
 [#537]: https://github.com/ericcornelissen/svgo-action/pull/537
 [#544]: https://github.com/ericcornelissen/svgo-action/pull/544
 [#546]: https://github.com/ericcornelissen/svgo-action/pull/546
+[#551]: https://github.com/ericcornelissen/svgo-action/pull/551
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/src/parsers/__mocks__/eval.ts
+++ b/src/parsers/__mocks__/eval.ts
@@ -1,0 +1,14 @@
+const parsedContent = { };
+
+const jsEval = jest.fn()
+  .mockReturnValue(parsedContent)
+  .mockName("parsers.jsEval");
+
+const yamlEval = jest.fn()
+  .mockReturnValue(parsedContent)
+  .mockName("parsers.yamlEval");
+
+export {
+  jsEval,
+  yamlEval,
+};

--- a/src/parsers/eval.ts
+++ b/src/parsers/eval.ts
@@ -1,0 +1,21 @@
+import _jsEval from "eval";
+import * as yaml from "js-yaml";
+
+function jsEval(raw: string) {
+  // Parsing JavaScript code with the "eval" package when no filename is
+  // provided fails due to an outdated reference to `module` that is invalid in
+  // modern JavaScript.
+  // See https://github.com/ericcornelissen/svgo-action/issues/548 for more
+  // information.
+  const jsEvalFilename = "x";
+  return _jsEval(raw, jsEvalFilename);
+}
+
+function yamlEval(raw: string) {
+  return yaml.load(raw);
+}
+
+export {
+  jsEval,
+  yamlEval,
+};

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,24 +1,14 @@
 import type { SafeParseFn } from "./types";
 
-import _jsEval from "eval";
-import * as yaml from "js-yaml";
-
 import { buildSafeParser } from "./builder";
-
-// Parsing JavaScript code with the "eval" package when no filename is provided
-// fails due to an outdated reference to `module` that is invalid in modern
-// JavaScript.
-// See https://github.com/ericcornelissen/svgo-action/issues/548 for more
-// information.
-const jsEvalFilename = "x";
+import { jsEval, yamlEval } from "./eval";
 
 function NewJavaScript(): SafeParseFn<unknown> {
-  const jsEval = (raw: string) => _jsEval(raw, jsEvalFilename);
   return buildSafeParser(jsEval);
 }
 
 function NewYaml(): SafeParseFn<unknown> {
-  return buildSafeParser(yaml.load);
+  return buildSafeParser(yamlEval);
 }
 
 export default {

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,11 +1,19 @@
 import type { SafeParseFn } from "./types";
 
-import jsEval from "eval";
+import _jsEval from "eval";
 import * as yaml from "js-yaml";
 
 import { buildSafeParser } from "./builder";
 
+// Parsing JavaScript code with the "eval" package when no filename is provided
+// fails due to an outdated reference to `module` that is invalid in modern
+// JavaScript.
+// See https://github.com/ericcornelissen/svgo-action/issues/548 for more
+// information.
+const jsEvalFilename = "x";
+
 function NewJavaScript(): SafeParseFn<unknown> {
+  const jsEval = (raw: string) => _jsEval(raw, jsEvalFilename);
   return buildSafeParser(jsEval);
 }
 

--- a/test/unit/parsers/eval.test.ts
+++ b/test/unit/parsers/eval.test.ts
@@ -1,0 +1,45 @@
+jest.mock("eval");
+jest.mock("js-yaml");
+
+import _jsEval from "eval";
+import * as yaml from "js-yaml";
+
+import * as evaluate from "../../../src/parsers/eval";
+
+const jsEval = _jsEval as jest.MockedFunction<typeof _jsEval>;
+const yamlLoad = yaml.load as jest.MockedFunction<typeof yaml.load>;
+
+describe("parsers/eval.js", () => {
+  beforeEach(() => {
+    jsEval.mockClear();
+    yamlLoad.mockClear();
+  });
+
+  describe("::jsEval", () => {
+    const content = "module.exports = { foo: 'bar' };";
+
+    test("does use eval", () => {
+      evaluate.jsEval(content);
+      expect(jsEval).toHaveBeenCalledWith(content, expect.stringMatching(".+"));
+    });
+
+    test("does not use js-yaml", () => {
+      evaluate.jsEval(content);
+      expect(yaml.load).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("::yamlEval", () => {
+    const content = "foo: bar";
+
+    test("does not use eval", () => {
+      evaluate.yamlEval(content);
+      expect(jsEval).not.toHaveBeenCalled();
+    });
+
+    test("does use js-yaml", () => {
+      evaluate.yamlEval(content);
+      expect(yaml.load).toHaveBeenCalledWith(content);
+    });
+  });
+});

--- a/test/unit/parsers/index.test.ts
+++ b/test/unit/parsers/index.test.ts
@@ -1,11 +1,8 @@
-jest.mock("eval");
-jest.mock("js-yaml");
 jest.mock("../../../src/parsers/builder");
-
-import jsEval from "eval";
-import * as yaml from "js-yaml";
+jest.mock("../../../src/parsers/eval");
 
 import * as builder from "../../../src/parsers/builder";
+import { jsEval, yamlEval } from "../../../src/parsers/eval";
 import parsers from "../../../src/parsers/index";
 
 const buildSafeParser = builder.buildSafeParser as jest.MockedFunction<typeof builder.buildSafeParser>; // eslint-disable-line max-len
@@ -16,27 +13,24 @@ describe("parsers/index.js", () => {
   });
 
   describe("::NewJavaScript", () => {
-    // The next test is temporarily disabled because `jsEval` cannot be directly
-    // provided to the `buildSafeParser` function.
-    // eslint-disable-next-line jest/no-disabled-tests
-    test.skip("does use eval", () => {
+    test("does use jsEval", () => {
       parsers.NewJavaScript();
       expect(buildSafeParser).toHaveBeenCalledWith(jsEval);
     });
 
-    test("does not use js-yaml", () => {
+    test("does not use yamlEval", () => {
       parsers.NewJavaScript();
-      expect(buildSafeParser).not.toHaveBeenCalledWith(yaml.load);
+      expect(buildSafeParser).not.toHaveBeenCalledWith(yamlEval);
     });
   });
 
   describe("::NewYaml", () => {
-    test("does use js-yaml", () => {
+    test("does not use jsEval", () => {
       parsers.NewYaml();
-      expect(buildSafeParser).toHaveBeenCalledWith(yaml.load);
+      expect(buildSafeParser).toHaveBeenCalledWith(yamlEval);
     });
 
-    test("does not use eval", () => {
+    test("does use yamlEval", () => {
       parsers.NewYaml();
       expect(buildSafeParser).not.toHaveBeenCalledWith(jsEval);
     });

--- a/test/unit/parsers/index.test.ts
+++ b/test/unit/parsers/index.test.ts
@@ -16,7 +16,10 @@ describe("parsers/index.js", () => {
   });
 
   describe("::NewJavaScript", () => {
-    test("does use eval", () => {
+    // The next test is temporarily disabled because `jsEval` cannot be directly
+    // provided to the `buildSafeParser` function.
+    // eslint-disable-next-line jest/no-disabled-tests
+    test.skip("does use eval", () => {
       parsers.NewJavaScript();
       expect(buildSafeParser).toHaveBeenCalledWith(jsEval);
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Update the call to [the eval package](https://www.npmjs.com/package/eval) to provide a (dummy) filename in order to prevent TypeError, specifically:

    .../svgo-action/node_modules/eval/eval.js:38
      var _filename = filename || module.parent.filename;
                                                ^
    TypeError: Cannot read properties of undefined (reading 'filename')

By providing a filename explicitly, the or (`||`) is short-circuited and hence the error is prevented. By preventing the error, parsing the SVGO JavaScript configuration works again - as can be seen from [the job summary](https://github.com/ericcornelissen/svgo-action/actions/runs/2309955413) for fe7f3c517e0e3fa9479f508ec4483b6fff1b8f7a.

Closes #548 