### PR TITLE
chore: bind `npm audit` to `npm run audit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
+    "audit": "npm audit",
     "build": "rollup --config rollup.config.js",
     "clean": "run-p clean:reports clean:temp",
     "clean:reports": "rm -rf ./_reports",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [n/a] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

Relates to #556, #557, #559

This is to support consistent auditing commands even if a certain branch (currently `main-v1` and `main-v2`) use a different audit command. For `main`/v3 there is currently no need for a custom auditing command, so this alias is created for consistency and convenience.

More specifically, `npm run audit` is the command to be used in #556 for continuous auditing of all (supported) major version branches. The other two (`main-v1` and `main-v2`) need a custom auditing command to be able to exclude one known vulnerability (in SVGO v1 that will never be resolved). Hence, they require a custom audit command. For convenience in the continuous auditing workflow, this adds the same audit command to the `main` branch (but simply as an alias for `npm audit`).
