### PR TITLE
Update warnings and notes in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,9 @@ relevant sections of this document.
   - [End-to-End Tests](#end-to-end-tests)
   - [Mutation Testing](#mutation-testing)
 
-> :information_source: If you want to make a contribution to v2 of the Action,
-> please refer to the [Contributing Guidelines for v2]. If you want to make a
-> contribution to v1 of the Action, please refer to the [Contributing Guidelines
-> for v1].
+> **Note** If you want to make a contribution to v2 of the Action, please refer
+> to the [Contributing Guidelines for v2]. If you want to make a contribution to
+> v1 of the Action, please refer to the [Contributing Guidelines for v1].
 
 ---
 
@@ -70,10 +69,10 @@ When you open a Pull Request that implements a new feature make sure to link to
 the relevant feature request and explain how you implemented the feature as
 clearly as possible.
 
-> :information_source: If you, for whatever reason, can no longer continue your
-> contribution please let us know. This gives others an opportunity to work on
-> it. If we don't hear from you for an extended period of time we may decide to
-> allow others to work on the feature you've been assigned to.
+> **Note** If you, for whatever reason, can no longer continue your contribution
+> please let us know. This gives others an opportunity to work on it. If we
+> don't hear from you for an extended period of time we may decide to allow
+> others to work on the feature you've been assigned to.
 
 ## Corrections
 
@@ -88,9 +87,9 @@ through ESLint, please update the `.eslintrc.js` configuration accordingly. If
 you need an extra package to be able to enforce your style please add it as a
 `devDependency`.
 
-> :information_source: Keep in mind that the developers of the project determine
-> the code style of as they see fit. For this reason, take the time to explain
-> why you think your changes improve the project.
+> **Note** Keep in mind that the developers of the project determine the code
+> style of as they see fit. For this reason, take the time to explain why you
+> think your changes improve the project.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ changed. To do this you can change the Workflow file that uses this Action to be
 triggered only when SVGs change. Update the value of `pull_request` and/or
 `push` as follows:
 
-> :warning: This will cause the entire Workflow to be run only when an SVG
+> **Warning** This will cause the entire Workflow to be run only when an SVG
 > changes. Jobs that should run for every push or Pull Request must be specified
 > in a separate Workflow file.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -15,7 +15,7 @@ to improve the documentation.
 
 ---
 
-> :warning: The Action will run on any event if [strict mode] is not enabled.
+> **Warning** The Action will run on any event if [strict mode] is not enabled.
 > However, this is not officially supported so you may encounter unexpected
 > behaviour.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -68,7 +68,7 @@ there are no changes, nothing will be committed or commented.
 Check out [what the Action outputs] to customize the commit message and Pull
 Request comment to your liking.
 
-> :warning: This does not work for Pull Requests from forks. This is because
+> **Warning** This does not work for Pull Requests from forks. This is because
 > GitHub Actions do not have permission to alter forked repositories.
 
 ```yaml

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -24,7 +24,7 @@ The `dry-run` input can be used to run the Action without having it write any
 changes. This can be useful for debugging or when you just want to give the
 Action a try.
 
-> :warning: If you misconfigure this input the Action assumes you wanted to
+> **Warning** If you misconfigure this input the Action assumes you wanted to
 > enable it and set `dry-run` to `true`.
 
 ### Examples
@@ -52,8 +52,8 @@ Action. By default, no files are ignored. The value is interpreted as a [glob],
 if there are multiple lines each line is interpreted as a [glob]. Any file that
 matches (any of) the configured glob(s) will **not** be optimized by the Action.
 
-> :information_source: Regardless of the value of this input, the Action will
-> only consider files with the `.svg` file extension.
+> **Note** Regardless of the value of this input, the Action will only consider
+> files with the `.svg` file extension.
 
 ### Examples
 
@@ -125,7 +125,7 @@ The `strict` input can be used to enable _strict mode_. In strict mode, the
 Action will fail in the event of a non-critical error (instead of just in the
 event of a critical error).
 
-> :warning: If you misconfigure this input the Action assumes you wanted to
+> **Warning** If you misconfigure this input the Action assumes you wanted to
 > enable it and set `strict` to `true`. This in turn results in the Action
 > failing due to an invalid input.
 
@@ -199,7 +199,7 @@ want to use. This can be either `2` for the latest v2 release, or the string
 `"project"` for the version of SVGO installed for your project. For `"project"`
 both SVGO v1 and v2 are supported.
 
-> :warning: SVGO v1 has been deprecated, we strongly recommend upgrading to
+> **Warning** SVGO v1 has been deprecated, we strongly recommend upgrading to
 > SVGO v2. For more information see the [SVGO v2 release notes].
 
 ### Examples


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

Update the warnings and notes in various MarkDown files from:

    > :information_source: Lorum upsum dolor ...

    > :warning: Lorum upsum dolor ...

to:

    > **Note** Lorum upsum dolor ...

    > **Warning** Lorum upsum dolor ...

which, when, rendered compares like this:

| What | Before | After |
| --- | --- | --- |
| Note | ![note before](https://user-images.githubusercontent.com/3742559/173237827-7d385494-53ac-498e-a44e-fe3564ddbc0c.png) | ![note after](https://user-images.githubusercontent.com/3742559/173237817-a66d7bc2-05df-41b7-8a8c-d615fa49d19c.png) |
| Warning | ![warning before](https://user-images.githubusercontent.com/3742559/173237796-b57e598c-9aac-468d-b794-f9432e0b6afa.png) | ![warning after](https://user-images.githubusercontent.com/3742559/173237779-2910fab9-ba1b-4286-9897-de7f5bb267a4.png) |

but is also nicer/more explicit when viewed in plaintext.


---


If anyone is interested in applying these changes to the documentation of [v1](https://github.com/ericcornelissen/svgo-action/blob/03fea329bdb9f1651b94564138b541d8a4a1c2a3/CONTRIBUTING.md) or [v2](https://github.com/ericcornelissen/svgo-action/blob/053b75ad810bf79d0a133961aca8f6f557c9fbe9/CONTRIBUTING.md), Pull Requests will be welcomed until their support has ended (see [SECURITY.md](https://github.com/ericcornelissen/svgo-action/blob/d07b8742d27767b3f0f21ef68a0bf610dcd74d65/SECURITY.md)).