### PR TITLE
Update CodeQL Action to latest version for `main-v1` branch

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -7,10 +7,14 @@ on:
   schedule:
     - cron: '0 7 * * 3'
 
+permissions: read-all
+
 jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2.1.12
         with:
           config-file: ./.github/codeql-config.yml
           languages: javascript
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2.1.12


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [n/a] I updated the documentation according to my changes.
- [n/a] I added my change to the Changelog.

### Description

PUpdate & pin the CodeQL Action to latest version to prevent issues do to the error seen here: https://github.com/ericcornelissen/svgo-action/runs/7059649262?check_suite_focus=true#step:3:126

Note, the `permissions` we're explicitly added in 0eeb9d21a56dc258a9252cc24f405a31ce302ee9 - it seems this is necessary given the CodeQL Action still failed in faeb19b189fd9525f97156e1bbdcf1460f64e648. The upgrade from v1 to v2 is kept because it doesn't hurt and the work is done now anyway.