### PR TITLE
Always upload coverage report to Codecov

### DIFF
--- a/.github/workflows/push-checks.yml
+++ b/.github/workflows/push-checks.yml
@@ -66,6 +66,7 @@ jobs:
           - unit
           - integration
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@v1.4.4
@@ -103,6 +104,7 @@ jobs:
           CI: true
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3.1.0
+        if: ${{ always() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./_reports/coverage/${{ matrix.type }}/lcov.info


### PR DESCRIPTION

<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Configure the `push-checks.yml` workflow to try to always upload a coverage report, even when the build fails, tests fail, or local coverage threshold wasn't met. This should provide richer data in Codecov.

