### PR TITLE
Add Action version in comments to Actions that use SHAs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # renovate: tag=v1.4.5
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -31,11 +31,11 @@ jobs:
             pkg-containers.githubusercontent.com:443
             uploads.github.com:443
       - name: Checkout Repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b398f525a5587552e573b247ac661067fafa920b
+        uses: github/codeql-action/init@b398f525a5587552e573b247ac661067fafa920b # renovate: tag=v2.1.22
         with:
           config-file: ./.github/codeql-config.yml
           languages: javascript
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b398f525a5587552e573b247ac661067fafa920b
+        uses: github/codeql-action/analyze@b398f525a5587552e573b247ac661067fafa920b # renovate: tag=v2.1.22

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -31,7 +31,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             uploads.github.com:443
       - name: Checkout Repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
+        uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748 # renovate: tag=v3.0.1
       - name: Initialize CodeQL
         uses: github/codeql-action/init@b398f525a5587552e573b247ac661067fafa920b # renovate: tag=v2.1.22
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [ ] I tested my changes.  --> _Can't be tested until after it's merged._
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Followup to #611, caused by https://github.com/ericcornelissen/svgo-action/pull/612#issuecomment-1244370155, based on [this RenovateBot documentation](https://github.com/renovatebot/renovate/blob/c4fa239bfaf61deef30c7d2f95afd77f5d4a7acf/lib/modules/manager/github-actions/readme.md).
