### PR TITLE
Update harden-runner configuration

### DIFF
--- a/.github/workflows/deps-checks.yml
+++ b/.github/workflows/deps-checks.yml
@@ -29,6 +29,7 @@ jobs:
             ghcr.io:443
             github.com:443
             nodejs.org:443
+            objects.githubusercontent.com:443
             registry.npmjs.org:443
             si05acprodeus1file1.blob.core.windows.net:443
       - name: Checkout repository


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Allow npm audit job to access `objects.githubusercontent.com:443` ([reference job (see annotations)](https://github.com/ericcornelissen/svgo-action/actions/runs/3120616848))
