### PR TITLE
Add scanning for secrets to the CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@ci/add-gitleaks
+    uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@main
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@main
+    uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@ci/add-gitleaks
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -10,6 +10,32 @@ on:
 permissions: read-all
 
 jobs:
+  secrets:
+    name: Secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # tag=v1.5.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            artifactcache.actions.githubusercontent.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@5b07ceca8a89dc14d2191f4a202bd28fae3e76ad # tag=v2.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_SUMMARY: true
   npm:
     name: npm (${{ matrix.ref }})
     runs-on: ubuntu-latest

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -23,6 +23,11 @@ if command -v shellcheck > /dev/null; then
   npm run lint:sh
 fi
 
+# Scan for secrets (if tool is installed)
+if command -v gitleaks > /dev/null; then
+  gitleaks protect
+fi
+
 # Format source code and update staged files
 npm run format
 git update-index --again

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -15,6 +15,11 @@ if command -v shellcheck > /dev/null; then
   npm run lint:sh
 fi
 
+# Scan for secrets (if tool is installed)
+if command -v gitleaks > /dev/null; then
+  gitleaks protect
+fi
+
 if [ "$(DID_STASH)" ]; then
   git stash pop --quiet --index
 fi


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Add a check to the `reusable-audit.yml` workflow to scan for secrets using Gitleaks in pushes (only pushed commits) and on schedule (historic scan)
