### PR TITLE
Audit only production dependencies for releases in nightly CI run

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -73,3 +73,4 @@ jobs:
       - name: Audit production npm dependencies
         if: ${{ startsWith(matrix.ref, 'v') }}
         run: npm run audit -- --production
+        # TODO: Replace with `run: npm run audit:prod`

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -67,5 +67,9 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm ci
-      - name: Audit dependencies
+      - name: Audit all npm dependencies
+        if: ${{ !startsWith(matrix.ref, 'v') }}
         run: npm run audit
+      - name: Audit production npm dependencies
+        if: ${{ startsWith(matrix.ref, 'v') }}
+        run: npm run audit -- --production


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes. (_in other projects_)
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

When auditing a release (a ref starting with "v"), don't bother auditing devDependencies, as these generally don't affect already released software. On non-release refs we're still interested in these because we generally still want to avoid vulnerabilities in all dependencies on development branches.

The `--production` flag is used even though it's deprecated because on v2 "better-npm-audit" is used instead, which does not yet support the "--omit dev" option.
