### PR TITLE
Add npm script to audit only production dependencies (v2)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+audit=false
 engine-strict=true
 lockfile-version=2
 save-exact=true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "lib/index.js",
   "scripts": {
     "audit": "better-npm-audit audit",
+    "audit:prod": "better-npm-audit audit --production",
     "prebuild": "node script/prebuild.js",
     "build": "ncc build src/index.ts -m -o lib",
     "clean": "run-p clean:reports clean:temp",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Add a new script similar to the `npm run audit` script that is supposed to be a version agnostic script for auditing production dependencies only. Relates to #628

Also disable auditing on install to reduce noise.
