### PR TITLE
Add npm script to audit only production dependencies (v3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "lib/index.cjs",
   "scripts": {
     "audit": "npm audit",
+    "audit:prod": "npm audit --omit dev",
     "build": "rollup --config rollup.config.js",
     "clean": "run-p clean:reports clean:temp",
     "clean:reports": "rm -rf ./_reports",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description


Add a new script similar to the `npm run audit` script that is supposed to be a version agnostic script for auditing production dependencies only. Relates to #628