### PR TITLE
Enable incremental mode for mutation testing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -165,6 +165,9 @@ module.exports = {
         "module": "readonly",
         "require": "readonly",
       },
+      rules: {
+        "@typescript-eslint/no-var-requires": "off",
+      },
     },
     { // Script files
       files: ["script/**/*.js"],

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -270,7 +270,6 @@ jobs:
   test-mutation:
     name: Test - mutation
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'main' || github.ref_name == 'main-v2' }}
     needs:
       - test
     steps:
@@ -293,6 +292,13 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
+      - name: Cache Stryker incremental report
+        uses: actions/cache@ac8075791e805656e71b4ba23325ace9e3421120 # tag=v3.0.9
+        with:
+          path: _reports/mutation/stryker-incremental.json
+          key: mutation-${{ github.run_number }}
+          restore-keys: |
+            mutation-
       - name: Install dependencies
         run: npm ci
       - name: Run mutation tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,10 +240,14 @@ at `_reports/mutation/index.html`. Alternatively, you can find a report for the
 `main` branch online as a [Stryker Dashboard].
 
 By default the mutation tests run on all the source code using all the unit
-tests. Since this is a slow process, you can change the mutation test config (in
-`stryker.config.js`) to focus on a subset of the source code or unit tests (we
-ask that you don't commit such changes). For example, to run mutation tests for
-a particular file you can change the Stryker configuration as follows.
+tests. The first time you run the mutation tests can be rather slow. However,
+this project leverages Stryker's incremental mode, meaning that subsequent runs
+of the mutation tests are much faster.
+
+If you don't have time for an initial slow run, you can opt to change the config
+in `stryker.config.js` to focus on a subset of the source code or unit tests
+(you should never commit such changes). For example, to run mutation tests for
+a particular source code file you can change the config as follows.
 
 ```diff
   mutate: [

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,6 @@
 // Check out Jest at: https://jestjs.io/
 
-import process from "node:process";
+const process = require("node:process");
 
 let coverageSubDir = "all";
 if (process.argv.includes("test/integration")) {
@@ -9,7 +9,7 @@ if (process.argv.includes("test/integration")) {
   coverageSubDir = "unit";
 }
 
-export default {
+module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   cacheDirectory: "./.cache/jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@rollup/plugin-node-resolve": "14.1.0",
         "@rollup/plugin-typescript": "8.5.0",
         "@stryker-mutator/core": "6.2.2",
+        "@stryker-mutator/jest-runner": "6.2.2",
         "@stryker-mutator/typescript-checker": "6.2.2",
         "@types/jest": "29.1.1",
         "@types/jest-when": "3.5.2",
@@ -2825,6 +2826,45 @@
       "engines": {
         "node": ">=14.18.0"
       }
+    },
+    "node_modules/@stryker-mutator/jest-runner": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-6.2.2.tgz",
+      "integrity": "sha512-xWuzuBUIB2MQVJBCdK5K8/SRV4fu2+wAd9FoZY6AIkKCVv0Od0eYZ6MB78V6jSG9R2/KF9I+zzrQ94PEnp5zaQ==",
+      "dev": true,
+      "dependencies": {
+        "@stryker-mutator/api": "6.2.2",
+        "@stryker-mutator/util": "6.2.2",
+        "semver": "~7.3.7",
+        "tslib": "~2.4.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "~6.2.0"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/@stryker-mutator/typescript-checker": {
       "version": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@rollup/plugin-node-resolve": "14.1.0",
     "@rollup/plugin-typescript": "8.5.0",
     "@stryker-mutator/core": "6.2.2",
+    "@stryker-mutator/jest-runner": "6.2.2",
     "@stryker-mutator/typescript-checker": "6.2.2",
     "@types/jest": "29.1.1",
     "@types/jest-when": "3.5.2",

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -42,9 +42,9 @@ export default {
     fileName: `${reportsDir}/index.html`,
   },
   thresholds: {
+    break: 95,
     high: 95,
     low: 85,
-    break: 80,
   },
 
   tempDirName: ".temp/stryker",

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -1,5 +1,7 @@
 // Check out Stryker at: https://stryker-mutator.io/
 
+const reportsDir = "_reports/mutation";
+
 export default {
   coverageAnalysis: "perTest",
   inPlace: false,
@@ -12,6 +14,9 @@ export default {
   commandRunner: {
     command: "npm run test:unit -- --runInBand",
   },
+
+  incremental: true,
+  incrementalFile: `${reportsDir}/stryker-incremental.json`,
 
   timeoutMS: 25000,
   timeoutFactor: 2.5,
@@ -27,7 +32,7 @@ export default {
     "progress",
   ],
   htmlReporter: {
-    fileName: "_reports/mutation/index.html",
+    fileName: `${reportsDir}/index.html`,
   },
   thresholds: {
     high: 95,

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -11,8 +11,15 @@ export default {
     "!src/**/*.d.ts",
     "!src/**/__mocks__/**/*.ts",
   ],
-  commandRunner: {
-    command: "npm run test:unit -- --runInBand",
+
+  testRunner: "jest",
+  testRunnerNodeArgs: ["--experimental-vm-modules"],
+  jest: {
+    projectType: "custom",
+    configFile: "jest.config.cjs",
+    config: {
+      testMatch: ["<rootDir>/test/unit/**/*.test.ts"],
+    },
   },
 
   incremental: true,


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~
- [x] I updated the Contributing Guidelines

### Description

Enable [Stryker's incremental mode](https://stryker-mutator.io/blog/announcing-incremental-mode/) to make rerunning the mutation tests (after at least one run) much faster by avoiding testing mutants that have already been tested.

The speed up is substantial. Given zero changes to the source code or tests, the duration of the mutation tests in CI drops from [17m 21s](https://github.com/ericcornelissen/svgo-action/actions/runs/3183518848/jobs/5190874809) to [2m 3s](https://github.com/ericcornelissen/svgo-action/actions/runs/3183518848/jobs/5191239549), or about ~11% of the original runtime.