### PR TITLE
Don't use `::set-output` in e2e tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -201,25 +201,25 @@ jobs:
           SVG="${SVG//'%'/'%25'}"
           SVG="${SVG//$'\n'/'%0A'}"
           SVG="${SVG//$'\r'/'%0D'}"
-          echo "::set-output name=svg-one::$SVG"
+          echo "svg-one=$SVG" >> $GITHUB_OUTPUT
 
           export SVG=$(cat test/end-to-end/not-optimized-2.svg)
           SVG="${SVG//'%'/'%25'}"
           SVG="${SVG//$'\n'/'%0A'}"
           SVG="${SVG//$'\r'/'%0D'}"
-          echo "::set-output name=svg-two::$SVG"
+          echo "svg-two=$SVG" >> $GITHUB_OUTPUT
 
           export SVG=$(cat test/end-to-end/optimized-1.svg)
           SVG="${SVG//'%'/'%25'}"
           SVG="${SVG//$'\n'/'%0A'}"
           SVG="${SVG//$'\r'/'%0D'}"
-          echo "::set-output name=optimized-svg-one::$SVG"
+          echo "optimized-svg-one=$SVG" >> $GITHUB_OUTPUT
 
           export SVG=$(cat test/end-to-end/ignore/ignored-1.svg)
           SVG="${SVG//'%'/'%25'}"
           SVG="${SVG//$'\n'/'%0A'}"
           SVG="${SVG//$'\r'/'%0D'}"
-          echo "::set-output name=ignored-svg-one::$SVG"
+          echo "ignored-svg-one=$SVG" >> $GITHUB_OUTPUT
       - name: Run SVGO Action
         uses: ./
         id: svgo


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [ ] I left no linting errors in my changes.
- [ ] I tested my changes.
- [ ] I updated the documentation according to my changes.
- [ ] I added my change to the Changelog.

### Description

Closes #647
Relates to #648
