### PR TITLE
ci: don't use `::set-output` in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,11 @@ jobs:
         id: version
         run: |
           VERSION="v$(jq -r '.version' < package.json)"
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [ "$(git tag --list "$VERSION")" ]; then
-            echo "::set-output name=released::true"
+            echo "released=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=released::false"
+            echo "released=false" >> $GITHUB_OUTPUT
           fi
       - name: Release new version
         if: ${{ steps.version.outputs.released == 'false' }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Closes #648
Relates to #647, #650
