### PR TITLE
Automate GitHub Release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,13 +121,13 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [ "$(git tag --list "$VERSION")" ]; then
             echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
 
             # Set the `release_notes` output
             echo 'release_notes<<EOF' >> $GITHUB_OUTPUT
             echo "$(node script/get-release-notes.js)" >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
-          else
-            echo "released=false" >> $GITHUB_OUTPUT
           fi
       - name: Release new version
         if: ${{ steps.version.outputs.released == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
     permissions:
-      contents: write # To push a tag
+      contents: write # To push a tag and create a GitHub Release
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # tag=v1.5.0
@@ -121,6 +121,11 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [ "$(git tag --list "$VERSION")" ]; then
             echo "released=true" >> $GITHUB_OUTPUT
+
+            # Set the `release_notes` output
+            echo 'release_notes<<EOF' >> $GITHUB_OUTPUT
+            echo "$(node script/get-release-notes.js)" >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
           else
             echo "released=false" >> $GITHUB_OUTPUT
           fi
@@ -133,3 +138,9 @@ jobs:
 
           # Update what commit the v3 branch points to
           git push origin HEAD:v3
+      - name: Create GitHub Release
+        if: ${{ steps.version.outputs.released == 'false' }}
+        uses: ncipollo/release-action@4c75f0f2e4ae5f3c807cf0904605408e319dcaac # tag=v1.11.1
+        with:
+          body: ${{ steps.version.outputs.release_notes }}
+          tag: ${{ steps.version.outputs.version }}

--- a/script/bump-changelog.js
+++ b/script/bump-changelog.js
@@ -1,20 +1,18 @@
-import fs from "node:fs";
-import path from "node:path";
+import {
+  getChangelog,
+  getCurrentVersionHeader,
+  isCurrentVersionReleased,
+  writeChangelog,
+} from "./helpers.js";
 
 const STR_UNRELEASED = "## [Unreleased]";
 const STR_NO_CHANGES = "- _No changes yet_";
 
-const manifestFile = path.resolve("./package.json");
-const changelogFile = path.resolve("./CHANGELOG.md");
-
-const manifestRaw = fs.readFileSync(manifestFile).toString();
-const manifest = JSON.parse(manifestRaw);
-const version = manifest.version;
-
-const changelog = fs.readFileSync(changelogFile).toString();
-if (changelog.includes(`## [${version}]`)) {
-  throw new Error(`${version} already in CHANGELOG`);
+if (isCurrentVersionReleased()) {
+  throw new Error("The current version in the manifest was already released");
 }
+
+const changelog = getChangelog();
 
 const unreleasedTitleIndex = changelog.indexOf(STR_UNRELEASED);
 if (unreleasedTitleIndex === -1) {
@@ -35,7 +33,7 @@ const day = _day < 10 ? `0${_day}` : _day;
 const newChangelog =
   changelog.slice(0, unreleasedTitleIndex + STR_UNRELEASED.length) +
   `\n\n${STR_NO_CHANGES}` +
-  `\n\n## [${version}] - ${year}-${month}-${day}` +
+  `\n\n${getCurrentVersionHeader()} - ${year}-${month}-${day}` +
   changelog.slice(unreleasedTitleIndex + STR_UNRELEASED.length);
 
-fs.writeFileSync(changelogFile, newChangelog);
+writeChangelog(newChangelog);

--- a/script/get-release-notes.js
+++ b/script/get-release-notes.js
@@ -1,26 +1,23 @@
-import fs from "node:fs";
-import path from "node:path";
 import process from "node:process";
 
-const manifestFile = path.resolve("./package.json");
-const changelogFile = path.resolve("./CHANGELOG.md");
+import {
+  getChangelog,
+  getCurrentVersionHeader,
+  isCurrentVersionReleased,
+} from "./helpers.js";
 
-const manifestRaw = fs.readFileSync(manifestFile).toString();
-const manifest = JSON.parse(manifestRaw);
-const version = manifest.version;
-const versionHeader = `## [${version}]`;
-
-const changelog = fs.readFileSync(changelogFile).toString();
-if (!changelog.includes(versionHeader)) {
-  throw new Error(`${version} missing from CHANGELOG`);
+if (!isCurrentVersionReleased()) {
+  throw new Error("The current version in the manifest hasn't been released");
 }
 
-const startIndex = changelog.indexOf(versionHeader) + versionHeader.length + 13;
-const endIndex = startIndex + (
-  changelog
-    .substring(startIndex)
-    .indexOf("## [")
-);
+const changelog = getChangelog();
+const versionHeader = getCurrentVersionHeader();
+
+const startIndex = changelog.indexOf(versionHeader)
+  + versionHeader.length
+  + " - 2022-01-01".length;
+const endIndex = startIndex
+  + changelog.substring(startIndex).indexOf("## [");
 
 const releaseNotes = changelog.substring(startIndex, endIndex);
 process.stdout.write(releaseNotes);

--- a/script/get-release-notes.js
+++ b/script/get-release-notes.js
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const manifestFile = path.resolve("./package.json");
+const changelogFile = path.resolve("./CHANGELOG.md");
+
+const manifestRaw = fs.readFileSync(manifestFile).toString();
+const manifest = JSON.parse(manifestRaw);
+const version = manifest.version;
+const versionHeader = `## [${version}]`;
+
+const changelog = fs.readFileSync(changelogFile).toString();
+if (!changelog.includes(versionHeader)) {
+  throw new Error(`${version} missing from CHANGELOG`);
+}
+
+const startIndex = changelog.indexOf(versionHeader) + versionHeader.length + 13;
+const endIndex = startIndex + (
+  changelog
+    .substring(startIndex)
+    .indexOf("## [")
+);
+
+const releaseNotes = changelog.substring(startIndex, endIndex);
+process.stdout.write(releaseNotes);
+process.stdout.write("\n");

--- a/script/helpers.js
+++ b/script/helpers.js
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Get the project's changelog.
+ *
+ * @returns {string} The changelog.
+ */
+export function getChangelog() {
+  const changelogFilePath = getPathTo("CHANGELOG.md");
+  const changelogRaw = readFile(changelogFilePath);
+  return changelogRaw;
+}
+
+/**
+ * Get the changelog version header for the current version
+ *
+ * @returns {string} The version header.
+ */
+export function getCurrentVersionHeader() {
+  const manifest = getManifest();
+  const version = manifest.version;
+  const versionHeader = `## [${version}]`;
+  return versionHeader;
+}
+
+/**
+ * Get the project's manifest.
+ *
+ * @returns {Record<string, any>} The manifest as a JavaScript.
+ */
+export function getManifest() {
+  const manifestFilePath = getPathTo("package.json");
+  const manifestRaw = readFile(manifestFilePath);
+  const manifest = JSON.parse(manifestRaw);
+  return manifest;
+}
+
+/**
+ * Get the path to a file in the project.
+ *
+ * @param {string} relativePath A project-root relative file path.
+ * @returns {string} The absolute path
+ */
+function getPathTo(relativePath) {
+  const absolutePath = path.resolve(".", relativePath);
+  return absolutePath;
+}
+
+/**
+ * Check if the current version stated in the package manifest has been
+ * released according to the changelog.
+ *
+ * @returns {boolean} `true` if released, `false` otherwise.
+ */
+export function isCurrentVersionReleased() {
+  const changelog = getChangelog();
+  const versionHeader = getCurrentVersionHeader();
+  return changelog.includes(versionHeader);
+}
+
+/**
+ * Read a file.
+ *
+ * @param {string} file An absolute file path.
+ * @returns {string} The file contents.
+ */
+function readFile(filepath) {
+  const content = fs.readFileSync(filepath).toString();
+  return content;
+}
+
+/**
+ * Rewrite the project's changelog.
+ *
+ * @param {string} changelog The new changelog contents.
+ */
+export function writeChangelog(changelog) {
+  const changelogFile = getPathTo("CHANGELOG.md");
+  fs.writeFileSync(changelogFile, changelog);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
  - _To the extend possible yes, but the ultimate test is to publish a new release._
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Closes #666

Update the release automation to _also_ automatically create a [GitHub Release](https://github.com/ericcornelissen/svgo-action/blob/c336d3e59d012371838b56048b88f1f7dd344530/RELEASE.md#creating-a-github-release) for every release.

I've used [actions/create-release](https://github.com/actions/create-release/tree/4c11c9fe1dcd9636620a16455165783b20fc7ea0) in the past, but it's been deprecated so shouldn't be used. So, I went through the listed alternatives and went with the most recently updated one, which is [ncipollo/release-action](https://github.com/ncipollo/release-action).