### PR TITLE
Bump `svgo-v3` from 3.0.0 to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v3 to `v3.0.1`. ([#672])
 
 ## [3.1.0] - 2022-10-26
 
@@ -464,5 +464,6 @@ Versioning].
 [#622]: https://github.com/ericcornelissen/svgo-action/pull/622
 [#634]: https://github.com/ericcornelissen/svgo-action/pull/634
 [#661]: https://github.com/ericcornelissen/svgo-action/pull/661
+[#672]: https://github.com/ericcornelissen/svgo-action/pull/672
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "js-yaml": "4.1.0",
         "minimatch": "5.1.0",
         "svgo-v2": "npm:svgo@2.8.0",
-        "svgo-v3": "npm:svgo@3.0.0"
+        "svgo-v3": "npm:svgo@3.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "17.2.0",
@@ -13256,9 +13256,9 @@
     },
     "node_modules/svgo-v3": {
       "name": "svgo",
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.0.tgz",
-      "integrity": "sha512-mSqPn6RDeNqJvCeqHERlfWJjd4crP/2PgFelil9WpTwC4D3okAUopPsH3lnEyl7ONXfDVyISOihDjO0uK8YVAA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.1.tgz",
+      "integrity": "sha512-6kiDrstRCmA600TySGBu4VNA/FdEriOv7PKQRDOyIaVYUNamWvDSZjgMsM+mB0r0y5T7S3P5DkZJSIBQ/9QEsg==",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "js-yaml": "4.1.0",
     "minimatch": "5.1.0",
     "svgo-v2": "npm:svgo@2.8.0",
-    "svgo-v3": "npm:svgo@3.0.0"
+    "svgo-v3": "npm:svgo@3.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "17.2.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes. (CI)
- [x] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Bump [`svgo-v3`](https://github.com/ericcornelissen/svgo-action/blob/8ff5a4c081905f3a3c011c9b64d0dd8d8c038f24/package.json#L72) from 3.0.0 to 3.0.1
