### PR TITLE
Update path filters in CI workflows

### DIFF
--- a/.github/workflows/check-configs.yml
+++ b/.github/workflows/check-configs.yml
@@ -2,9 +2,9 @@ name: Config
 on:
   pull_request:
     paths:
-      - ./.github/workflows/check-configs.yml
-      - ./.github/codecov.yml
-      - ./script/validate-codecov-config.sh
+      - .github/workflows/check-configs.yml
+      - .github/codecov.yml
+      - script/validate-codecov-config.sh
   push:
     branches:
       - main


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes. (_see CI checks_)
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Followup to #679 - It looks like a leading `./` on path filters doesn't work for GitHub Actions.
