### PR TITLE
Mirror filters between `push`es and `pull_request`s

### DIFF
--- a/.github/workflows/check-configs.yml
+++ b/.github/workflows/check-configs.yml
@@ -1,18 +1,18 @@
-definitions:
-  path-filters: &path-filters
-    - .github/workflows/check-configs.yml
-    - .github/codecov.yml
-    - script/validate-codecov-config.sh
-
 name: Config
 on:
   pull_request:
-    paths: *path-filters
+    paths:
+      - .github/workflows/check-configs.yml
+      - .github/codecov.yml
+      - script/validate-codecov-config.sh
   push:
     branches:
       - main
       - main-v2
-    paths: *path-filters
+    paths:
+      - .github/workflows/check-configs.yml
+      - .github/codecov.yml
+      - script/validate-codecov-config.sh
 
 permissions: read-all
 

--- a/.github/workflows/check-configs.yml
+++ b/.github/workflows/check-configs.yml
@@ -1,14 +1,18 @@
+definitions:
+  path-filters: &path-filters
+    - .github/workflows/check-configs.yml
+    - .github/codecov.yml
+    - script/validate-codecov-config.sh
+
 name: Config
 on:
   pull_request:
-    paths:
-      - .github/workflows/check-configs.yml
-      - .github/codecov.yml
-      - script/validate-codecov-config.sh
+    paths: *path-filters
   push:
     branches:
       - main
       - main-v2
+    paths: *path-filters
 
 permissions: read-all
 


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Followup to #680 - prevent unexpected failures (in this case) on the `main` branch when the workflow didn't run on a Pull Request.