### PR TITLE
Bump `svgo-v3` from 3.0.1 to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v3 to `v3.0.2`. ([#683])
 
 ## [3.1.1] - 2022-11-11
 
@@ -469,5 +469,6 @@ Versioning].
 [#634]: https://github.com/ericcornelissen/svgo-action/pull/634
 [#661]: https://github.com/ericcornelissen/svgo-action/pull/661
 [#672]: https://github.com/ericcornelissen/svgo-action/pull/672
+[#683]: https://github.com/ericcornelissen/svgo-action/pull/683
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "js-yaml": "4.1.0",
         "minimatch": "5.1.0",
         "svgo-v2": "npm:svgo@2.8.0",
-        "svgo-v3": "npm:svgo@3.0.1"
+        "svgo-v3": "npm:svgo@3.0.2"
       },
       "devDependencies": {
         "@commitlint/cli": "17.2.0",
@@ -13256,9 +13256,9 @@
     },
     "node_modules/svgo-v3": {
       "name": "svgo",
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.1.tgz",
-      "integrity": "sha512-6kiDrstRCmA600TySGBu4VNA/FdEriOv7PKQRDOyIaVYUNamWvDSZjgMsM+mB0r0y5T7S3P5DkZJSIBQ/9QEsg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "js-yaml": "4.1.0",
     "minimatch": "5.1.0",
     "svgo-v2": "npm:svgo@2.8.0",
-    "svgo-v3": "npm:svgo@3.0.1"
+    "svgo-v3": "npm:svgo@3.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "17.2.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes. (CI)
- [x] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Bump [`svgo-v3`](https://github.com/ericcornelissen/svgo-action/blob/337d70dfe503eb1cbdee498a78982a323ed69a02/package.json#L73) from 3.0.1 to 3.0.2

Given that the update didn't change anything user facing for the purposes of this project, no release will be created for this update.

#### References

- [Release notes](https://github.com/svg/svgo/releases/tag/v3.0.2)
- [Diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2Fsvgo%2F-%2Fsvgo-3.0.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2Fsvgo%2F-%2Fsvgo-3.0.2.tgz)
