### PR TITLE
Refactor `switch`-statements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -156,6 +156,7 @@ module.exports = {
           },
           multilineDetection: "brackets",
         }],
+        "@typescript-eslint/switch-exhaustiveness-check": ["error"],
       },
     },
     { // Configuration files (JavaScript)

--- a/src/svgo/index.ts
+++ b/src/svgo/index.ts
@@ -1,7 +1,6 @@
 import type { error } from "../errors";
 import type { SupportedSvgoVersions, SVGOptimizer } from "./types";
 
-import errors from "../errors";
 import createSvgoOptimizerForProject from "./project";
 import StubSVGOptimizer from "./stub";
 import svgoV2 from "./v2";
@@ -36,9 +35,6 @@ function New({
     break;
   case "3":
     [svgOptimizer, err] = svgoV3.New(svgoConfig);
-    break;
-  default:
-    err = errors.New(`unknown value '${svgoVersion}'`);
     break;
   }
 

--- a/test/integration/svgo.test.ts
+++ b/test/integration/svgo.test.ts
@@ -92,17 +92,6 @@ describe("package svgo", () => {
     describe("initialization fails", () => {
       const svgoConfig = { };
 
-      test("invalid svgo-version", () => {
-        const config = {
-          svgoVersion: {
-            value: "foobar" as SupportedSvgoVersions,
-          },
-        };
-
-        const [, err] = SVGO.New({ config, svgoConfig });
-        expect(err).not.toBeNull();
-      });
-
       test("project-level SVGO missing", () => {
         importCwdSilent.mockReturnValueOnce(undefined);
 

--- a/test/unit/svgo/index.test.ts
+++ b/test/unit/svgo/index.test.ts
@@ -98,20 +98,5 @@ describe("svgo/index.ts", () => {
         expect(createSvgoOptimizerForProject).toHaveBeenCalledWith(svgoConfig);
       });
     });
-
-    test.each([
-      "foobar",
-      "Hello world!",
-    ])("unknown string ('%s')", (svgoVersionValue) => {
-      const config = {
-        svgoVersion: {
-          value: svgoVersionValue as SupportedSvgoVersions,
-        },
-      };
-
-      const [, err] = svgo.New({ config, svgoConfig });
-      expect(err).not.toBeNull();
-      expect(err).toEqual(expect.stringContaining("unknown value"));
-    });
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Enable the `@typescript-eslint/switch-exhaustiveness-check` rule and refactor switch statements to be both exhaustive (covering all branches) and minimal (covering no unnecessary branches).