### PR TITLE
Pin all runner images in GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-configs.yml
+++ b/.github/workflows/check-configs.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   codecov:
     name: Codecov
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@main
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -43,7 +43,7 @@ jobs:
         run: npm run build
   codeql:
     name: CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       security-events: write
     steps:
@@ -69,7 +69,7 @@ jobs:
         uses: github/codeql-action/analyze@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
   licenses:
     name: Licenses
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -96,7 +96,7 @@ jobs:
         run: npm run license-check
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -144,7 +144,7 @@ jobs:
         run: npm run lint:ci
   test:
     name: Test - ${{ matrix.type }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
     strategy:
@@ -199,7 +199,7 @@ jobs:
           flags: ${{ matrix.type }}
   test-e2e:
     name: Test - end-to-end (${{ matrix.test.description }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
       - test
@@ -335,7 +335,7 @@ jobs:
           fi
   test-mutation:
     name: Test - mutation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - test
     steps:
@@ -375,7 +375,7 @@ jobs:
         run: npm run test:mutation
   vet:
     name: Vet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions: read-all
 jobs:
   initiate:
     name: Initiate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write # To push a commit
@@ -94,7 +94,7 @@ jobs:
           commit-message: "chore: version bump"
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'push' }}
     permissions:
       contents: write # To push a tag and create a GitHub Release

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   secrets:
     name: Secrets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -39,7 +39,7 @@ jobs:
           GITLEAKS_ENABLE_SUMMARY: true
   npm:
     name: npm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update all GitHub Actions workflows to use a specific runner image for all jobs. The chosen images are based on what the documented `latest` images are on December 13, 2022. Doing this should help with reproducibility.

Upgrading to more recent images may be done separately.