### PR TITLE
Fixes for contributor system compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "license-check": "licensee --errors-only",
     "lint": "run-p --silent 'lint:!(ci|sh|docker)'",
     "lint:ci": "actionlint",
-    "lint:docker": "docker run -i --rm --mount \"type=bind,source=$(pwd)/.hadolint.yml,target=/.config/hadolint.yaml\" hadolint/hadolint@sha256:9259e253a4e299b50c92006149dd3a171c7ea3c5bd36f060022b5d2c1ff0fbbe < ./.devcontainer/Dockerfile",
+    "lint:docker": "docker run -i --rm --mount \"type=bind,source=$(pwd)/.hadolint.yml,target=/.config/hadolint.yaml\" hadolint/hadolint:v2.12.0 < ./.devcontainer/Dockerfile",
     "lint:js": "npm run _eslint -- . --ext .cjs,.js",
     "lint:json": "npm run _eslint -- . --ext .json",
     "lint:md": "run-p --silent 'lint:md:*'",

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -3,7 +3,7 @@
 . "$(dirname "$0")/common.sh"
 
 if [ ! "$(IS_MERGING)" ]; then
-  LIB_STAGED_COUNT=$(git diff --name-only --staged lib/ | wc --lines)
+  LIB_STAGED_COUNT=$(git diff --name-only --staged lib/ | wc -l)
   if [ "$LIB_STAGED_COUNT" -ne "0" ]; then
     echo "[INFO] All changes to the lib/ directory have been unstaged."
     echo "[INFO] Changes in the lib/ directory should not be committed."


### PR DESCRIPTION
### Checklist


- [ ] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

- Don't use "--lines" flag for `wc` as it's not supported on all systems.
- Don't pin hadolint to SHA as SHAs are architecture-specific.