### PR TITLE
Ensure all vetting tools are always run in the CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -396,5 +396,15 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Vet
-        run: npm run vet
+      - name: Set setup success flag
+        id: setup
+        run: echo 'succeeded=true' >> "$GITHUB_OUTPUT"
+      - name: Vet dependencies
+        if: ${{ steps.setup.outputs.succeeded }}
+        run: npm run vet:deps
+      - name: Vet imports
+        if: ${{ steps.setup.outputs.succeeded }}
+        run: npm run vet:imports
+      - name: Vet types
+        if: ${{ steps.setup.outputs.succeeded }}
+        run: npm run vet:ts

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -125,20 +125,17 @@ jobs:
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Install dependencies
         run: npm clean-install
-      - name: Set setup success flag
-        id: setup
-        run: echo 'succeeded=true' >> "$GITHUB_OUTPUT"
       - name: Lint CI
-        if: ${{ steps.setup.outputs.succeeded }}
+        if: ${{ failure() || success() }}
         run: npm run lint:ci
       - name: Lint source code
-        if: ${{ steps.setup.outputs.succeeded }}
+        if: ${{ failure() || success() }}
         run: npm run lint
       - name: Lint Dockerfile
-        if: ${{ steps.setup.outputs.succeeded }}
+        if: ${{ failure() || success() }}
         run: npm run lint:docker
       - name: Lint shell scripts
-        if: ${{ steps.setup.outputs.succeeded }}
+        if: ${{ failure() || success() }}
         run: npm run lint:sh
   test:
     name: Test - ${{ matrix.type }}
@@ -396,15 +393,12 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Set setup success flag
-        id: setup
-        run: echo 'succeeded=true' >> "$GITHUB_OUTPUT"
       - name: Vet dependencies
-        if: ${{ steps.setup.outputs.succeeded }}
+        if: ${{ failure() || success() }}
         run: npm run vet:deps
       - name: Vet imports
-        if: ${{ steps.setup.outputs.succeeded }}
+        if: ${{ failure() || success() }}
         run: npm run vet:imports
       - name: Vet types
-        if: ${{ steps.setup.outputs.succeeded }}
+        if: ${{ failure() || success() }}
         run: npm run vet:types

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -407,4 +407,4 @@ jobs:
         run: npm run vet:imports
       - name: Vet types
         if: ${{ steps.setup.outputs.succeeded }}
-        run: npm run vet:ts
+        run: npm run vet:types

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vet": "run-p --silent 'vet:*'",
     "vet:deps": "depcheck",
     "vet:imports": "unimported",
-    "vet:ts": "type-coverage --at-least 100 --project tsconfig.json --strict"
+    "vet:types": "type-coverage --at-least 100 --project tsconfig.json --strict"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update the "Check / Vet" job such that it always runs all vetting tools regardless of any one tool failing. The job will still fail if any one vetting tool reports an error.

Relates to #717