### PR TITLE
Separate "Audit" job from the "Check" workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,16 @@
+name: Audit
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+      - main-v2
+      - v2
+      - v3
+
+permissions: read-all
+
+jobs:
+  audit:
+    name: Audit
+    uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@main

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,9 +11,6 @@ on:
 permissions: read-all
 
 jobs:
-  audit:
-    name: Audit
-    uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@main
   build:
     name: Build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Separate the "Check / Audit" job from other "Check /" jobs in order to make it possible to always require all "Check /" jobs to pass. Audits may start failing due to external changes as opposed to internal changes, as such, a failure of the job should be manually reviewed and, motivating this change primarily, not affect things such as the "CI Status" badge in the `README.md`.

This follows recent work around upgrading `json5` following a vulnerability in it, see #724, #725, and #727.