### PR TITLE
Sign `lib/index.cjs` for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,23 +98,21 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     permissions:
       contents: write # To push a tag and create a GitHub Release
+      id-token: write # To perform keyless signing with cosign
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0 # To obtain all tags
+      - name: Install cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+        with:
+          cosign-release: v1.13.1
       - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # tag=v3.5.1
         with:
@@ -156,6 +154,22 @@ jobs:
         if: ${{ steps.version.outputs.released == 'false' }}
         run: |
           git push origin 'HEAD:${{ steps.major-version.outputs.result }}'
+      - name: Sign Action
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign-blob \
+            --output-certificate index.cjs.cert \
+            --output-signature index.cjs.sign \
+            lib/index.cjs
+      - name: Verify signatures
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign verify-blob \
+            --certificate index.cjs.cert \
+            --signature index.cjs.sign \
+            lib/index.cjs
       - name: Create GitHub Release
         if: ${{ steps.version.outputs.released == 'false' }}
         uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
@@ -163,3 +177,6 @@ jobs:
           body: ${{ steps.version.outputs.release_notes }}
           name: Release ${{ steps.version.outputs.version }}
           tag: ${{ steps.version.outputs.version }}
+          artifacts: >-
+            index.cjs.cert,
+            index.cjs.sign


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update the publish workflow to automatically create a signature of the Action "executable" upon a release using [cosign]'s `sign-blob` functionality.

To be able to do this, cosign is installed (pinned to a specific version more on this in a bit). Prior to the creation of the GitHub release, cosign is invoked with the `sign-blob` subcommand to sign the file `lib/index.cjs` using "[keyless signing]". The output of this, the signature and ephemeral key certificate, are attached to the release so that users can verify the signature using the command:

    COSIGN_EXPERIMENTAL=1 \
    cosign verify-blob \
      --certificate index.cjs.cert \
      --signature index.cjs.sign \
      lib/index.cjs

This verification is included in the job to ensure it succeeds (and also as a way of implicitly documenting how to perform the verification).

Note that "keyless signing" [2] is an experimental feature, hence the `COSIGN_EXPERIMENTAL=1` environment variable and the pinning of cosign to a specific version (to avoid running into breaking changes unexpectedly).

[cosign]: https://github.com/sigstore/cosign
[keyless signing]: https://github.com/sigstore/cosign/blob/5282e31/KEYLESS.md

