### PR TITLE
Explicitly configure GitHub Release properties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,3 +180,6 @@ jobs:
           artifacts: >-
             index.cjs.cert,
             index.cjs.sign
+          draft: false
+          makeLatest: ${{ steps.major-version.outputs.result == 'v3' }}
+          prerelease: false

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -140,8 +140,10 @@ For major releases, some additional steps are required. This may include:
 
 - Ensure any references to the major version in the documentation (external and
   internal) are updated.
-- Update the automated release workflow to create releases for the new major
-  version.
+- Update the continuous delivery workflow to mark only releases for the new
+  major version as `latest`.
+- Update continuous integration workflows to run on the old and new major
+  version branches (`vX` and `main-vX`).
 - Update the issue templates to align with the new major version.
 
 Make sure these additional changes are included in the release Pull Request.


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes. (_based on another project of mine_)
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update the configuration of `ncipollo/release-action` to be explicit about various properties of the release. Notably, make the release `latest` only if the major version is in fact the latest major version.