### PR TITLE
Update `.nsprc` for (main-)v2

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,3 @@
 {
-  "1070415": "From a transitive dependency of svgo@v1 which is a mandatory dependency of this project (removing it is a breaking change), but svgo@v1 no longer receives updates"
+  "GHSA-rp65-9cf3-cjxr": "From a transitive dependency of svgo@v1 which is a mandatory dependency of this project (removing it is a breaking change), but svgo@v1 no longer receives updates"
 }


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Following https://github.com/ericcornelissen/svgo-action/actions/runs/3879875895

The node security id seems to have just changed over night, switching to the GHSA which should be more reliable.