### PR TITLE
Don't audit v2 branch (temporarily)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,4 +11,4 @@ jobs:
     name: Audit
     uses: ericcornelissen/svgo-action/.github/workflows/reusable-audit.yml@main
     with:
-      refs: '["main", "v3", "main-v2", "v2"]'
+      refs: '["main", "v3", "main-v2"]'


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes. ([link](https://github.com/ericcornelissen/svgo-action/actions/runs/3896012013))
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Relates to #734

Avoid scanning the `v2` branch temporarily following the changes of 25074c348a0da235d21233f8253a11e72bcc9dc3 - until that's released the v2 scan will always incorrectly fail, producing noise. Since
1. v2 isn't actively developed, and
2. v2 does not receive automatic dependency updates the nightly audit of `main-v2`
it should suffice to catch vulnerabilities in production dependencies and by extension cause v2 to be updated in a timely manner.

After 25074c348a0da235d21233f8253a11e72bcc9dc3 has landed in a release, this change is ideally reverted (unless support for v2 has ended per the Security Policy).