### PR TITLE
Track hadolint in `.tool-versions`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ jobs:
           - act
           - actionlint
           - cosign
+          - hadolint
           - shellcheck
     steps:
       - name: Harden runner

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,4 +3,5 @@
 act 0.2.40
 actionlint 1.6.22
 cosign 1.13.1
+hadolint 2.12.0
 shellcheck 0.9.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ To be able to contribute you need the following tooling:
 - [Node.js] v18 or higher and [npm] v8.1.2 or higher;
 - (Recommended) a code editor with [EditorConfig] support;
 - (Suggested) [actionlint] (see `.tool-versions` for preferred version);
+- (Suggested) [hadolint] (see `.tool-versions` for preferred version);
 - (Suggested) [ShellCheck] (see `.tool-versions` for preferred version);
 - (Optional) [act] v0.2.22 or higher;
 - (Optional) [Docker];

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "license-check": "licensee --errors-only",
     "lint": "run-p --silent 'lint:!(ci|sh|docker)'",
     "lint:ci": "actionlint",
-    "lint:docker": "docker run -i --rm --mount \"type=bind,source=$(pwd)/.hadolint.yml,target=/.config/hadolint.yaml\" hadolint/hadolint:v2.12.0 < ./.devcontainer/Dockerfile",
+    "lint:docker": "hadolint ./.devcontainer/Dockerfile",
     "lint:js": "npm run _eslint -- . --ext .cjs,.js",
     "lint:json": "npm run _eslint -- . --ext .json",
     "lint:md": "run-p --silent 'lint:md:*'",

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -23,7 +23,7 @@ npm run lint:ws
 if command -v actionlint > /dev/null; then
   npm run lint:ci
 fi
-if command -v docker > /dev/null; then
+if command -v hadolint > /dev/null; then
   npm run lint:docker
 fi
 if command -v shellcheck > /dev/null; then

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -15,7 +15,7 @@ npm run test:unit
 if command -v actionlint > /dev/null; then
   npm run lint:ci
 fi
-if command -v docker > /dev/null; then
+if command -v hadolint > /dev/null; then
   npm run lint:docker
 fi
 if command -v shellcheck > /dev/null; then


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] I added my change to the Changelog.

### Description

Relates to #711.

Track the version of [hadolint](https://github.com/hadolint/hadolint) used in the `.tool-versions` file.