### PR TITLE
Bump transitive dependency simple-git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13240,9 +13240,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
-      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update simple-git from 3.15.1 to 3.16.0 following a `npm audit` warning for <3.16.0 for CVE-2022-25860.

As a (transitive) dev-dependency this change does not need to be released:

```
npm ls simple-git
svgo-action@3.1.3 .../svgo-action
└─┬ unimported@1.24.0
  └── simple-git@3.15.1
```

See also [the nightly run of Jan 27, 2023](https://github.com/ericcornelissen/svgo-action/actions/runs/4021236931).