### PR TITLE
Pre-format in pre-commit hook

### DIFF
--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -10,6 +10,7 @@ if [ -z "$(IS_MERGING)" ]; then
     git restore --staged lib/
   fi
 
+  npm run format
   git stash push --quiet --include-untracked --keep-index
 fi
 


### PR DESCRIPTION
### Checklist

- [x] ~~I left no linting errors in my changes~~.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update the pre-commit hook to format before stashing. This has the effect of avoiding stash-merge conflicts due to the stash pop at the end of the hook in some cases. This is considered not harmful as, eventually, all code (staged or not) must be formatted.
