### PR TITLE
Update semgrep integration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -142,8 +142,6 @@ jobs:
     name: Semgrep
     runs-on: ubuntu-22.04
     if: ${{ github.actor != 'dependabot[bot]' }}
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     permissions:
       security-events: write # To upload SARIF results
     container:
@@ -153,6 +151,8 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Perform Semgrep analysis
         run: semgrep ci --sarif --output semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload Semgrep report to GitHub
         uses: github/codeql-action/upload-sarif@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2.2.5
         if: ${{ failure() || success() }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -141,15 +141,23 @@ jobs:
   semgrep:
     name: Semgrep
     runs-on: ubuntu-22.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    permissions:
+      security-events: write # To upload SARIF results
     container:
       image: returntocorp/semgrep
     steps:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Perform Semgrep analysis
-        run: semgrep ci
+        run: semgrep ci --sarif --output semgrep.sarif
+      - name: Upload Semgrep report to GitHub
+        uses: github/codeql-action/upload-sarif@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2.2.5
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: semgrep.sarif
   test:
     name: Test - ${{ matrix.type }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Checklist

- [ ] I left no linting errors in my changes.
- [ ] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Followup to #762

Update the "Check / Semgrep" job to have Semgrep generate an output in [SARIF](https://sarifweb.azurewebsites.net/) format and upload that to GitHub using [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action). See also the [relevant GitHub documentation](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github) as well as the [Semgrep CLI documentation](https://semgrep.dev/docs/cli-reference/).

Also don't run Semgrep for PRs by Dependabot as it doesn't have access to `secrets.SEMGREP_APP_TOKEN`. In turn the `semgrep` invocation doesn't do anything, as a result of which uploading the SARIF file will fail (leading to an job failure).