### PR TITLE
Update egress policy for "Check / CodeQL"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,9 +50,11 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
             api.github.com:443
             ghcr.io:443
             github.com:443
+            objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
             uploads.github.com:443
       - name: Checkout repository


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update the "Check / CodeQL" job's egress policy to include two more endpoints. This follows recent failed runs of the job where it was not able to download the CodeQL CLI, due to the missing endpoint `objects.githubusercontent.com`.

The other endpoint was added as a precaution, this is an official endpoint used by GitHub Actions. It may or may not cause the job to fail, but will in most likelihood show up as blocked at some point, which isn't ideal.

