### PR TITLE
Partially address vulnerability in `yaml@<2.2.2`

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,2 +1,3 @@
 {
+  "GHSA-f9xv-q969-pqx4": "Potential parsing error in the 'yaml' package through depcheck is not a security concern for this project"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5440,9 +5440,9 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -15248,9 +15248,9 @@
       }
     },
     "node_modules/yaml-eslint-parser/node_modules/yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
         "node": ">= 14"


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

1. Ran `npm audit --fix` to patch the path `eslint-plugin-yml`>`yaml-eslint-parser`>`yaml`.
2. Ignore GHSA-f9xv-q969-pqx4 for the path `depcheck`>`cosmiconfig`>`yaml`. See comment in the `.nsprc` file for details

As a devDependency this does not need to be included in the changelog nor does it need to be released.