### PR TITLE
chore: ignore GHSA-f9xv-q969-pqx4 (for v2 of this Action)

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,4 @@
 {
+  "GHSA-f9xv-q969-pqx4": "Potential parsing error in the 'yaml' package through @commitlint/cli is not a security concern for this project",
   "GHSA-rp65-9cf3-cjxr": "From a transitive dependency of svgo@v1 which is a mandatory dependency of this project (removing it is a breaking change), but svgo@v1 no longer receives updates"
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Relates to #785

Ignore GHSA-f9xv-q969-pqx4 for the path `@commitlint/cli`>`@commitlint/load`>`cosmiconfig`>`yaml`. See comment in the `.nsprc` file for more details.

As a devDependency this does not need to be included in the changelog nor does it need to be released.
