### PR TITLE
Update `.nsprc`

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,2 @@
 {
-  "GHSA-f9xv-q969-pqx4": "Potential parsing error in the 'yaml' package through depcheck is not a security concern for this project"
 }


### PR DESCRIPTION
### Checklist

- [ ] I left no linting errors in my changes.
- [ ] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Partially reverts #785

The original affected range of the vulnerability being ignored here was incorrect. Given the correct affected range this ignore is not necessary.
