### PR TITLE
Add explicit license for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ This Action requires network access to the endpoint `api.github.com:443` when
 triggered by `pull_request:` or `push:`. Otherwise it does not require any
 network access.
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
 [ci-url]: https://github.com/ericcornelissen/svgo-action/actions/workflows/check.yml
 [ci-image]: https://github.com/ericcornelissen/svgo-action/actions/workflows/check.yml/badge.svg
 [coverage-url]: https://codecov.io/gh/ericcornelissen/svgo-action
@@ -119,10 +123,12 @@ network access.
 [mutation-url]: https://dashboard.stryker-mutator.io/reports/github.com/ericcornelissen/svgo-action/main
 [mutation-image]: https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fericcornelissen%2Fsvgo-action%2Fmain
 
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [creating a workflow file]: https://docs.github.com/en/actions/learn-github-actions/introduction-to-github-actions#create-an-example-workflow
-[permissions]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions
-[svgo]: https://github.com/svg/svgo
 [examples]: ./docs/examples.md
 [inputs documentation]: ./docs/inputs.md
+[mit]: https://opensource.org/license/mit/
+[permissions]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions
+[svgo]: https://github.com/svg/svgo
 [what the action does for each `on` event]: ./docs/events.md
 [what the action outputs]: ./docs/outputs.md

--- a/docs/events.md
+++ b/docs/events.md
@@ -166,15 +166,21 @@ The following [outputs] are available in the `repository_dispatch` and
 | `OPTIMIZED_COUNT` | Yes       |
 | `SVG_COUNT`       | Yes       |
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
 [`pull_request` events]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
 [`push` events]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#push
 [`repository_dispatch` events]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch
 [`schedule` events]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
 [`workflow_dispatch` events]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
 [branch and tag filters]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
-[open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [inputs]: ./inputs.md
+[mit]: https://opensource.org/license/mit/
+[open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
 [outputs]: ./outputs.md
 [path filters]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths
-[svgs that are ignored]: ./inputs.md#ignore
 [strict mode]: ./inputs.md#strict-mode
+[svgs that are ignored]: ./inputs.md#ignore

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -344,7 +344,13 @@ jobs:
           svgo-version: project
 ```
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
 [actions/checkout]: https://github.com/marketplace/actions/checkout
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
+[mit]: https://opensource.org/license/mit/
 [npm]: https://www.npmjs.com/
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
 [path filters]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -228,9 +228,15 @@ To use the SVGO version used by your project:
     svgo-version: project
 ```
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
 [`on: pull_request`]: ./events.md#on-pull_request
 [`on: push`]: ./events.md#on-push
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [glob]: https://en.wikipedia.org/wiki/Glob_(programming)
+[mit]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
 [svgo]: https://github.com/svg/svgo
 [svgo v2 release notes]: https://github.com/svg/svgo/releases/tag/v2.0.0

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -42,4 +42,10 @@ steps:
     #                   | The id of the SVGO Action's step
 ```
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
+[mit]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Make documentation text available under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) and snippets under the MIT license (like the source code).

Most of the documentation has been edited by anyone other than me so there can be no disputes over this license change or addition. The exception to this is [`docs/events.md`](https://github.com/ericcornelissen/svgo-action/blame/c76acd186c066dd45b7bece567eca64815c5c356/docs/events.md) which was edited by an external contributor in #452 / 561d74aea3c931e3e956ff044594844e4ba52e6c. However, their changes have since been overwritten, so the current version of the file can be re-licensed without their consent.
