### PR TITLE
Improve link text for the MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ network access.
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [ci-url]: https://github.com/ericcornelissen/svgo-action/actions/workflows/check.yml
 [ci-image]: https://github.com/ericcornelissen/svgo-action/actions/workflows/check.yml/badge.svg
@@ -127,7 +127,7 @@ _Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
 [creating a workflow file]: https://docs.github.com/en/actions/learn-github-actions/introduction-to-github-actions#create-an-example-workflow
 [examples]: ./docs/examples.md
 [inputs documentation]: ./docs/inputs.md
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [permissions]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions
 [svgo]: https://github.com/svg/svgo
 [what the action does for each `on` event]: ./docs/events.md

--- a/docs/events.md
+++ b/docs/events.md
@@ -168,7 +168,7 @@ The following [outputs] are available in the `repository_dispatch` and
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [`pull_request` events]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
 [`push` events]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#push
@@ -178,7 +178,7 @@ _Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
 [branch and tag filters]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [inputs]: ./inputs.md
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
 [outputs]: ./outputs.md
 [path filters]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -346,11 +346,11 @@ jobs:
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [actions/checkout]: https://github.com/marketplace/actions/checkout
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [npm]: https://www.npmjs.com/
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
 [path filters]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -230,13 +230,13 @@ To use the SVGO version used by your project:
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [`on: pull_request`]: ./events.md#on-pull_request
 [`on: push`]: ./events.md#on-push
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [glob]: https://en.wikipedia.org/wiki/Glob_(programming)
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md
 [svgo]: https://github.com/svg/svgo
 [svgo v2 release notes]: https://github.com/svg/svgo/releases/tag/v2.0.0

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -44,8 +44,8 @@ steps:
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/svgo-action/issues/new?labels=docs&template=documentation.md


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Followup to #795

Improve link text for the MIT license from "MIT" to "MIT license" as "MIT" could just as easily refer to MIT the institute.
