### PR TITLE
Remove DevSkim analysis

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,34 +79,6 @@ jobs:
           languages: javascript
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@0225834cc549ee0ca93cb085b92954821a145866 # v2.3.5
-  devskim:
-    name: DevSkim
-    runs-on: ubuntu-22.04
-    permissions:
-      security-events: write # To upload SARIF results
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            ghcr.io:443
-            github.com:443
-            objects.githubusercontent.com:443
-            pkg-containers.githubusercontent.com:443
-            uploads.github.com:443
-      - name: Checkout repository
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Perform DevSkim analysis
-        uses: microsoft/DevSkim-Action@068952be6217a6b5f73edaca2764b5e131938da2 # v1.0.6
-      - name: Upload DevSkim report to GitHub
-        uses: github/codeql-action/upload-sarif@0225834cc549ee0ca93cb085b92954821a145866 # v2.3.5
-        if: ${{ failure() || success() }}
-        with:
-          sarif_file: devskim-results.sarif
   licenses:
     name: Licenses
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Checklist

- [x] ~~I left no linting errors in my changes.~~
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Drop the CI job that runs DevSkim. While it did serve up some useful results (notably the SHA1 integrity values in `package-lock.json`), it comes with even more false positives. As a result, it's more noisy than useful in a continuous setting.

Relates to #778, #801