### PR TITLE
Set `audit=false` for npm by default

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+audit=false
 engine-strict=true
 lockfile-version=3
 save-exact=true


### PR DESCRIPTION
### Checklist

- [x] ~~I left no linting errors in my changes.~~
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Disable automatic auditing when running npm commands by setting `audit=false` in the local npm configuration (.npmrc) in order to avoid confusion about problems reported by npm's native auditing tooling w.r.t. `npm run audit(:prod)`.
