### PR TITLE
Make EditorConfig configuration more granular

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,23 +4,49 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
-indent_size = 2
 insert_final_newline = true
 max_line_length = 80
 trim_trailing_whitespace = true
 
-[*.yml]
+[*.{js,cjs}]
+indent_style = space
+indent_size = 2
+
+[*.json]
 indent_style = space
 indent_size = 2
 max_line_length = unset
 
 [*.md]
-indent_size = unset # Irregular indentation needed for, e.g., numbered lists
+indent_size = unset
+indent_style = space
 max_line_length = unset # Handled by markdownlint
 
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[*.svg]
+indent_style = space
+indent_size = 2
+
+[*.{ts}]
+indent_style = space
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+max_line_length = unset
+
 [lib/*]
-max_line_length = unset # Irrelevant for generated files
+indent_size = unset
+indent_style = space
+max_line_length = unset
 
 [Dockerfile]
 indent_style = tab
+
+[LICENSE]
+indent_size = unset
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,12 +9,12 @@ max_line_length = 80
 trim_trailing_whitespace = true
 
 [*.{js,cjs}]
-indent_style = space
 indent_size = 2
+indent_style = space
 
 [*.json]
-indent_style = space
 indent_size = 2
+indent_style = space
 max_line_length = unset
 
 [*.md]
@@ -23,20 +23,20 @@ indent_style = space
 max_line_length = unset # Handled by markdownlint
 
 [*.sh]
-indent_style = space
 indent_size = 2
+indent_style = space
 
 [*.svg]
-indent_style = space
 indent_size = 2
+indent_style = space
 
-[*.{ts}]
-indent_style = space
+[*.ts]
 indent_size = 2
+indent_style = space
 
 [*.{yaml,yml}]
-indent_style = space
 indent_size = 2
+indent_style = space
 max_line_length = unset
 
 [lib/*]


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update the EditorConfig configuration to be configured by filetype in order to be more granular, making is to that changing the configuration for a given file type does not require splitting or having to create a new rule for other file types.