### PR TITLE
Use `npx` instead of a path to invoke commitlint

### DIFF
--- a/script/hooks/commit-msg
+++ b/script/hooks/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-./node_modules/.bin/commitlint --edit "$1"
+npx commitlint --edit "$1"


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Relates to #1, #295

Improve the `commit-msg` hook script by leveraging [`npx`](https://www.npmjs.com/package/npx) to invoke [`commitlint`](https://commitlint.js.org/) in order to decouple it from the internals of how npm decide to do `.bin` scripts. Note that due to `commitlint` being a devDependency of this project, `npx` will prefer using the local version (provided `npm install`, or similar, has been run).


