### PR TITLE
Upgrade runtime from `node16` to `node20`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning].
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Update Node.js runtime to v20. ([#837])
+
+### Changes
+
 - Update dependency `minimatch`. ([#802], [#821], [#830])
 
 ## [3.1.4] - 2023-04-30
@@ -536,5 +542,6 @@ Versioning].
 [#802]: https://github.com/ericcornelissen/svgo-action/pull/802
 [#821]: https://github.com/ericcornelissen/svgo-action/pull/821
 [#830]: https://github.com/ericcornelissen/svgo-action/pull/830
+[#837]: https://github.com/ericcornelissen/svgo-action/pull/837
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
     description: The number of SVGs that were detected
 
 runs:
-  using: node16
+  using: node20
   main: lib/index.cjs
 
 branding:


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Upgrade to the latest available Node.js runtime for Actions. This is a breaking change since self-hosted runners may not support the new runtime.

