### PR TITLE
Remove explicit `CI: true` from CI configurations

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,7 +200,6 @@ jobs:
         run: npm clean-install
       - name: Run ${{ matrix.type }} tests
         env:
-          CI: true
           TYPE: ${{ matrix.type }}
         run: npm run "coverage:${TYPE}"
       - name: Upload code coverage
@@ -396,7 +395,6 @@ jobs:
         run: npm clean-install
       - name: Run mutation tests
         env:
-          CI: true
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_TOKEN }}
         run: npm run test:mutation
   vet:


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

It's set by default <https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/>