### PR TITLE
Update the tooling update commit message

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,5 +48,6 @@ jobs:
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@9c4504b41601cf1457decd293d6590e2a3ee2f81 # v0.3.5
         with:
+          commit-message: "chore: update tooling"
           max: 1
           token: ${{ steps.automation-token.outputs.token }}


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Configure the tooling update commit message to be conventional. Support for this was [added in v0.3.3](https://github.com/ericcornelissen/tool-versions-update-action/blob/872b7f0bb67e5e629ce50416c1f26fd67a64f97c/CHANGELOG.md#033---2023-07-22) (and this project is currently [using v0.3.5](https://github.com/ericcornelissen/svgo-action/blob/7093d04c5022cc4155dad92d1bd48b6abac495b3/.github/workflows/nightly.yml#L49)).