### PR TITLE
Avoid publishing failure due to signature verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - main-v3
 
 permissions: read-all
 
@@ -138,14 +139,6 @@ jobs:
             --yes \
             --output-certificate index.cjs.cert \
             --output-signature index.cjs.sign \
-            lib/index.cjs
-      - name: Verify signature
-        run: |
-          cosign verify-blob \
-            --certificate-identity ericornelissen@gmail.com \
-            --certificate-oidc-issuer https://github.com/login/oauth \
-            --certificate index.cjs.cert \
-            --signature index.cjs.sign \
             lib/index.cjs
       - name: Create GitHub Release
         uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Addresses https://github.com/ericcornelissen/svgo-action/pull/856#issuecomment-1732272251

Remove the verification of the cosign signature directly after creation to avoid failing the release if the invocation is configured **incorrectly**. The signature _should_ be right anyway, as it's created validly.

Also, align the workflow with #857 (04a82e74314d75be4604e407339d3c5e2dbf2bc2).