### PR TITLE
Ignore GHSA-m95q-7qp3-xv42 (v3)

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,2 +1,6 @@
 {
+  "GHSA-m95q-7qp3-xv42": {
+    "active": true,
+    "notes": "ReDoS in the devDependency tree without mitigation available. Mitigation should ideally be applied when available."
+  }
 }


### PR DESCRIPTION
### Checklist

- [x] ~~I left no linting errors in my changes.~~
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Configure `better-npm-audit` to ignore GHSA-m95q-7qp3-xv42. See diff for motivation to ignore.

See also #862.