### PR TITLE
Update deprecation notice to warning for v3 release line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update deprecation notice to a warning. ([#872])
 
 ## [3.1.5] - 2023-09-23
 
 - Update dependency `minimatch`. ([#802], [#821], [#830])
-- Update deprecation notice to recommend switching to v4. ([#854])
+- Add deprecation notice recommending switching to v4 of this Action. ([#854])
 
 ## [3.1.4] - 2023-04-30
 
@@ -547,5 +547,6 @@ Versioning].
 [#821]: https://github.com/ericcornelissen/svgo-action/pull/821
 [#830]: https://github.com/ericcornelissen/svgo-action/pull/830
 [#854]: https://github.com/ericcornelissen/svgo-action/pull/854
+[#872]: https://github.com/ericcornelissen/svgo-action/pull/872
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/src/helpers/deprecation.ts
+++ b/src/helpers/deprecation.ts
@@ -1,5 +1,5 @@
 interface Core {
-  notice(msg: string): void;
+  warning(msg: string): void;
 }
 
 interface Params {
@@ -9,7 +9,7 @@ interface Params {
 function deprecationWarnings({
   core,
 }: Params): void {
-  core.notice(
+  core.warning(
     "General support for SVGO Action v3 ended 2023-09-23. Security " +
     "updates will be supported until 2023-12-31. Please upgrade to SVGO " +
     "Action v4 as soon as possible.",

--- a/test/unit/helpers/deprecation.test.ts
+++ b/test/unit/helpers/deprecation.test.ts
@@ -15,7 +15,7 @@ describe("helpers/deprecation.ts", () => {
 
   test("deprecation warning for v3 of the Action", () => {
     deprecationWarnings({ core });
-    expect(core.notice).toHaveBeenCalledWith(
+    expect(core.warning).toHaveBeenCalledWith(
       "General support for SVGO Action v3 ended 2023-09-23. Security " +
       "updates will be supported until 2023-12-31. Please upgrade to SVGO " +
       "Action v4 as soon as possible.",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Update deprecation notice to warning for v3 to upgrade to v4. Planned to be merged/released towards the end of November 2023.
