### PR TITLE
Prefer `Uint8Array` over `Buffer`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,6 +60,24 @@ module.exports = {
       ignoreTrailingComments: true,
     }],
     "no-console": ["error"],
+    "no-restricted-globals": [
+      "error",
+      {
+        name: "Buffer",
+        message: "Use Uint8Array instead.",
+      },
+    ],
+    "no-restricted-imports": [
+      "error",
+      {
+        name: "buffer",
+        message: "Use Uint8Array instead.",
+      },
+      {
+        name: "node:buffer",
+        message: "Use Uint8Array instead.",
+      },
+    ],
     "object-curly-spacing": ["error", "always"],
     "quotes": ["error", "double"],
     "semi": ["error", "always"],
@@ -144,6 +162,17 @@ module.exports = {
         project: "./tsconfig.json",
       },
       rules: {
+        "@typescript-eslint/ban-types": [
+          "error",
+          {
+            types: {
+              Buffer: {
+                message: "Use Uint8Array instead.",
+                suggest: ["Uint8Array"],
+              },
+            },
+          },
+        ],
         "@typescript-eslint/block-spacing": ["error"],
         "@typescript-eslint/consistent-generic-constructors": [
           "error",

--- a/src/file-systems/base.ts
+++ b/src/file-systems/base.ts
@@ -18,7 +18,7 @@ interface Params {
     };
     openSync(path: string, flags: "r" | "w"): number;
     readdirSync(path: string): Iterable<string>;
-    readFileSync(handle: number): Buffer;
+    readFileSync(handle: number): Uint8Array;
     writeFileSync(handle: number, content: string): void;
   };
   readonly path: {

--- a/test/__common__/node-fs.mock.ts
+++ b/test/__common__/node-fs.mock.ts
@@ -22,7 +22,7 @@ const readdirSync = jest.fn()
 
 // https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options
 const readFileSync = jest.fn()
-  .mockReturnValue(Buffer.from(""))
+  .mockReturnValue(Uint8Array.from([]))
   .mockName("fs.readFileSync");
 
 // https://nodejs.org/api/fs.html#fs_fs_writefilesync_file_data_options

--- a/test/unit/file-systems/base.test.ts
+++ b/test/unit/file-systems/base.test.ts
@@ -6,6 +6,7 @@ jest.mock("node:fs", () => require("../../__common__/node-fs.mock.ts"));
 jest.mock("node:path", () => require("../../__common__/node-path.mock.ts"));
 jest.mock("../../../src/errors");
 
+import { Buffer } from "node:buffer"; // eslint-disable-line no-restricted-imports
 import * as fs from "node:fs";
 import * as path from "node:path";
 


### PR DESCRIPTION
### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] ~~I left no linting errors in my changes.~~
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description
Switch `Buffer`s out for `Uint8Array`s where possible, also linting for it to ensure consistency going forward. Based on <https://sindresorhus.com/blog/goodbye-nodejs-buffer>.

Closes #870 
