### PR TITLE
Don't run optional linters multiple times in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -144,18 +144,8 @@ jobs:
         uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
       - name: Install dependencies
         run: npm clean-install
-      - name: Lint CI
-        if: ${{ failure() || success() }}
-        run: npm run lint:ci
-      - name: Lint source code
-        if: ${{ failure() || success() }}
+      - name: Lint
         run: npm run lint
-      - name: Lint Dockerfile
-        if: ${{ failure() || success() }}
-        run: npm run lint:docker
-      - name: Lint shell scripts
-        if: ${{ failure() || success() }}
-        run: npm run lint:sh
   reproducible:
     name: Reproducible build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Relates to #869, don't waste resources in CI by running optional linters multiple times now that `npm run lint` runs all linters by default.