### PR TITLE
Require 100% mutation coverage

### DIFF
--- a/stryker.config.js
+++ b/stryker.config.js
@@ -37,9 +37,9 @@ export default {
     fileName: "_reports/mutation/index.html",
   },
   thresholds: {
-    break: 95,
-    high: 95,
-    low: 85,
+    break: 100,
+    high: 100,
+    low: 100,
   },
 
   tempDirName: ".temp/stryker",

--- a/test/unit/filters/glob.test.ts
+++ b/test/unit/filters/glob.test.ts
@@ -23,7 +23,7 @@ describe("filters/glob.ts", () => {
     test("a file matching the glob", async () => {
       const query = "foo/bar.svg";
 
-      const glob = jest.fn().mockReturnValue(["foo/bar.svg"]);
+      const glob = jest.fn().mockReturnValue(["path/to/foo/bar.svg"]);
       const globber = { glob, globGenerator, getSearchPaths };
       globCreateMock.mockResolvedValueOnce(globber);
 


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Update the Stryker configuration to require 100% mutation coverage (i.e. `break` at a value of 100). This is in order to avoid the (current) scenario where a mutant is uncaught unknowingly.
