### PR TITLE
Add SPDX license IDs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 ARG NODE_VERSION
 ARG IMAGE_VARIANT
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,8 @@ about: Report a problem with the SVGO Action.
 labels: bug
 ---
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Bug Report
 
 <!-- The version of the Action you're using -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -4,6 +4,8 @@ about: Report problems with SVGO Action's documentation.
 labels: docs
 ---
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Documentation
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,8 @@ about: Request a feature for the SVGO Action.
 labels: enhancement
 ---
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Feature Request
 
 <!-- The version of the Action you're using -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,6 +4,8 @@ about: Ask a question about the SVGO Action.
 labels: question
 ---
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Question
 
 <!-- The version of the Action you're using -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- markdownlint-disable MD041-->
 
 ### Checklist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Changelog
 
 All notable changes to the _SVGO Action_ will be documented in this file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The _SVGO Action_ project welcomes contributions and corrections of all forms.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # SVGO Action
 
 [![Build status][ci-image]][ci-url]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Release Guidelines
 
 If you need to release a new version of the _SVGO Action_, follow the guidelines

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the _SVGO Action_ project take security issues seriously. We

--- a/__mocks__/@actions/core.ts
+++ b/__mocks__/@actions/core.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const defaultInputs: Record<string, string> = {
   "repo-token": "foobar",
   "dry-run": "false",

--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const context = {
   eventName: "push",
   payload: {

--- a/__mocks__/@actions/glob.ts
+++ b/__mocks__/@actions/glob.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const create = jest.fn()
   .mockReturnValue({
     glob: jest.fn()

--- a/__mocks__/eval.ts
+++ b/__mocks__/eval.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const _eval = jest.fn()
   .mockName("eval::default");
 

--- a/__mocks__/import-cwd.ts
+++ b/__mocks__/import-cwd.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const silent = jest.fn()
   .mockReturnValue(undefined)
   .mockName("import-cwd::silent");

--- a/__mocks__/svgo-v2.ts
+++ b/__mocks__/svgo-v2.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const optimize = jest.fn()
   .mockReturnValue({ data: "<svg></svg>" })
   .mockName("svgo-v2.optimize");

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # SVGO Action Events
 
 This documentation describes the behavior of the SVGO Action for every GitHub

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # SVGO Action Examples
 
 This documentation provides various example workflows of how you might use the

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # SVGO Action Inputs
 
 This documentation describes all the inputs of the SVGO Action.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # SVGO Action Outputs
 
 This documentation describes all values outputted by the SVGO Action. These

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ import typescript from "@rollup/plugin-typescript";
 export default {
   input: "src/index.ts",
   output: {
+    banner: "// @license MIT",
     file: "lib/index.cjs",
     format: "cjs",
   },

--- a/script/bump-changelog.js
+++ b/script/bump-changelog.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   getChangelog,
   getCurrentVersionHeader,

--- a/script/get-release-notes.js
+++ b/script/get-release-notes.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import process from "node:process";
 
 import {

--- a/script/helpers.js
+++ b/script/helpers.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import fs from "node:fs";
 import path from "node:path";
 

--- a/script/hooks/commit-msg
+++ b/script/hooks/commit-msg
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
 . "$(dirname "$0")/_/husky.sh"
 
 npx commitlint --edit "$1"

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
 
 __TRUE="x"
 __FALSE=""

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 

--- a/src/__mocks__/errors.ts
+++ b/src/__mocks__/errors.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const isNull = (msg: string) => msg !== null;
 
 const Combine = jest.fn()

--- a/src/__mocks__/main.ts
+++ b/src/__mocks__/main.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const main = jest.fn()
   .mockName("main");
 

--- a/src/action-management/__mocks__/action-manager.ts
+++ b/src/action-management/__mocks__/action-manager.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const failIf = jest.fn()
   .mockName("action-management.StandardActionManager.failIf");
 

--- a/src/action-management/__mocks__/helpers.ts
+++ b/src/action-management/__mocks__/helpers.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const runIf = jest.fn()
   .mockName("action-management.runIf");
 

--- a/src/action-management/__mocks__/index.ts
+++ b/src/action-management/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import ActionManager from "./action-manager";
 
 const actionManager = new ActionManager();

--- a/src/action-management/action-manager.ts
+++ b/src/action-management/action-manager.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { ActionManager, Condition, Core } from "./types";
 
 import { runIf } from "./helpers";

--- a/src/action-management/helpers.ts
+++ b/src/action-management/helpers.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Condition } from "./types";
 
 function runIf(condition: Condition, fn: () => void): void {

--- a/src/action-management/index.ts
+++ b/src/action-management/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { ActionManager, Core } from "./types";
 
 import StandardActionManager from "./action-manager";

--- a/src/action-management/types.d.ts
+++ b/src/action-management/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 interface ActionManager {

--- a/src/clients/__mocks__/client.ts
+++ b/src/clients/__mocks__/client.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const files: Iterable<never> = [];
 
 const Client = jest.fn()

--- a/src/clients/__mocks__/index.ts
+++ b/src/clients/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import Client from "./client";
 
 const client = new Client();

--- a/src/clients/__mocks__/stub.ts
+++ b/src/clients/__mocks__/stub.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import Client from "./client";
 
 export default Client;

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type {
   CommitsGetCommitParams,
   CommitsGetCommitResponse,

--- a/src/clients/constants.ts
+++ b/src/clients/constants.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const INPUT_NAME_REPO_TOKEN = "repo-token";
 
 export {

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { GitHub, GitHubClient, Inputter } from "./types";
 import type { error } from "../errors";
 

--- a/src/clients/stub.ts
+++ b/src/clients/stub.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type {
   CommitsListFilesResponse,
   GitHubClient,

--- a/src/clients/types.d.ts
+++ b/src/clients/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 import type { GitHub } from "../types";
 import type { GitHub as _GitHub } from "@actions/github/lib/utils";

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const EVENT_PULL_REQUEST = "pull_request";
 const EVENT_PUSH = "push";
 const EVENT_REPOSITORY_DISPATCH = "repository_dispatch";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: MIT
+
 export * from "./events";

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 type error = string | null;
 
 function isNotNullError(err: error): boolean {

--- a/src/file-systems/__mocks__/__common__.ts
+++ b/src/file-systems/__mocks__/__common__.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const files: Iterable<never> = [];
 
 const fileSystemMock = {

--- a/src/file-systems/__mocks__/base.ts
+++ b/src/file-systems/__mocks__/base.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { fileSystemMock } from "./__common__";
 
 const NewBaseFileSystemMock = jest.fn()

--- a/src/file-systems/__mocks__/filtered.ts
+++ b/src/file-systems/__mocks__/filtered.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { fileSystemMock } from "./__common__";
 
 const NewFilteredFileSystemMock = jest.fn()

--- a/src/file-systems/__mocks__/index.ts
+++ b/src/file-systems/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { fileSystemMock } from "./__common__";
 
 const New = jest.fn()

--- a/src/file-systems/base.ts
+++ b/src/file-systems/base.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type {
   FileHandle,
   FileSystem,

--- a/src/file-systems/constants.ts
+++ b/src/file-systems/constants.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const LIST_FILES_ALWAYS_IGNORE: string[] = [
   ".git",
   "node_modules",

--- a/src/file-systems/filtered.ts
+++ b/src/file-systems/filtered.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type {
   FileFilter,
   FileHandle,

--- a/src/file-systems/index.ts
+++ b/src/file-systems/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FileFilter, FileSystem } from "./types";
 
 import * as fs from "node:fs";

--- a/src/file-systems/types.d.ts
+++ b/src/file-systems/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 type FileFilter = (filepath: string) => boolean;

--- a/src/filters/__mocks__/__common__.ts
+++ b/src/filters/__mocks__/__common__.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const filter = () => false;
 
 export {

--- a/src/filters/__mocks__/glob.ts
+++ b/src/filters/__mocks__/glob.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { filter } from "./__common__";
 
 const NewGlobFilter = jest.fn()

--- a/src/filters/__mocks__/index.ts
+++ b/src/filters/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import NewGlobFilter from "./glob";
 import NewPrFilesFilter from "./pr-files";
 import NewPushedFilesFilter from "./pushed-files";

--- a/src/filters/__mocks__/pr-files.ts
+++ b/src/filters/__mocks__/pr-files.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { filter } from "./__common__";
 
 const NewPrFilesFilter = jest.fn()

--- a/src/filters/__mocks__/pushed-files.ts
+++ b/src/filters/__mocks__/pushed-files.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { filter } from "./__common__";
 
 const NewPushedFilesFilter = jest.fn()

--- a/src/filters/__mocks__/svgs.ts
+++ b/src/filters/__mocks__/svgs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { filter } from "./__common__";
 
 const NewSvgsFilter = jest.fn()

--- a/src/filters/constants.ts
+++ b/src/filters/constants.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const STATUS_REMOVED = "removed";
 
 export {

--- a/src/filters/glob.ts
+++ b/src/filters/glob.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FilterFn } from "./types";
 
 import { create } from "@actions/glob";

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import NewGlobFilter from "./glob";
 import NewPrFilesFilter from "./pr-files";
 import NewPushedFilesFilter from "./pushed-files";

--- a/src/filters/pr-files.ts
+++ b/src/filters/pr-files.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FilterFn } from "./types";
 import type { error } from "../errors";
 

--- a/src/filters/pushed-files.ts
+++ b/src/filters/pushed-files.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FilterFn } from "./types";
 import type { error } from "../errors";
 

--- a/src/filters/svgs.ts
+++ b/src/filters/svgs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FilterFn } from "./types";
 
 const SVG_FILE_EXTENSION = ".svg";

--- a/src/filters/types.d.ts
+++ b/src/filters/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 type FilterFn = (filepath: string) => boolean;
 
 export type {

--- a/src/helpers/__mocks__/events.ts
+++ b/src/helpers/__mocks__/events.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const event = "push";
 
 const isClientRequired = jest.fn()

--- a/src/helpers/__mocks__/filters.ts
+++ b/src/helpers/__mocks__/filters.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const filters: Iterable<never> = [];
 
 const getFilters = jest.fn()

--- a/src/helpers/__mocks__/index.ts
+++ b/src/helpers/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { isClientRequired, isEventSupported } from "./events";
 import { getFilters } from "./filters";
 import { parseRawSvgoConfig } from "./svgo-config";

--- a/src/helpers/__mocks__/svgo-config.ts
+++ b/src/helpers/__mocks__/svgo-config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const svgoConfig = { };
 
 const parseRawSvgoConfig = jest.fn()

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   EVENT_PULL_REQUEST,
   EVENT_PUSH,

--- a/src/helpers/events.ts
+++ b/src/helpers/events.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   EVENT_PULL_REQUEST,
   EVENT_PUSH,

--- a/src/helpers/filters.ts
+++ b/src/helpers/filters.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { GitHub, GitHubClient } from "./types";
 import type { error } from "../errors";
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { isClientRequired, isEventSupported } from "./events";
 import { getFilters } from "./filters";
 import { parseRawSvgoConfig } from "./svgo-config";

--- a/src/helpers/svgo-config.ts
+++ b/src/helpers/svgo-config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 import parsers from "../parsers";

--- a/src/helpers/types.d.ts
+++ b/src/helpers/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { GitHubClient } from "../clients";
 import type { GitHub } from "../types";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 

--- a/src/inputs/__mocks__/__common__.ts
+++ b/src/inputs/__mocks__/__common__.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const defaultConfig = {
   ignoreGlobs: {
     provided: true,

--- a/src/inputs/__mocks__/getters.ts
+++ b/src/inputs/__mocks__/getters.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { defaultConfig } from "./__common__";
 
 const getIgnoreGlobs = jest.fn()

--- a/src/inputs/__mocks__/helpers.ts
+++ b/src/inputs/__mocks__/helpers.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const getDefaultSvgoConfigPath = jest.fn()
   .mockReturnValue("svgo.config.js")
   .mockName("inputs.getDefaultSvgoConfigPath");

--- a/src/inputs/__mocks__/index.ts
+++ b/src/inputs/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { defaultConfig } from "./__common__";
 
 const New = jest.fn()

--- a/src/inputs/constants.ts
+++ b/src/inputs/constants.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { InputterOptions } from "./types";
 
 const DEFAULT_IGNORE_GLOBS: ReadonlyArray<string> = [];

--- a/src/inputs/getters.ts
+++ b/src/inputs/getters.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Inputter, InputterOptions, InputValue } from "./types";
 import type { error } from "../errors";
 import type { SupportedSvgoVersions } from "../svgo";

--- a/src/inputs/helpers.ts
+++ b/src/inputs/helpers.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   DEFAULT_SVGO_V2_CONFIG_PATH,
 } from "./constants";

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Config, Inputter } from "./types";
 import type { error } from "../errors";
 

--- a/src/inputs/types.d.ts
+++ b/src/inputs/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SupportedSvgoVersions } from "../svgo";
 
 interface Config {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Core, GitHub } from "./types";
 
 import actionManagement from "./action-management";

--- a/src/optimize/__mocks__/index.ts
+++ b/src/optimize/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const data = { };
 
 const Files = jest.fn()

--- a/src/optimize/index.ts
+++ b/src/optimize/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type {
   FileHandle,
   FileSystem,

--- a/src/optimize/types.d.ts
+++ b/src/optimize/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 interface FileHandle {

--- a/src/outputs/__mocks__/index.ts
+++ b/src/outputs/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const Set = jest.fn()
   .mockReturnValue(null)
   .mockName("outputs.Set");

--- a/src/outputs/__mocks__/names.ts
+++ b/src/outputs/__mocks__/names.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const getOutputNamesFor = jest.fn()
   .mockReturnValue([[], null])
   .mockName("outputs.getOutputNamesFor");

--- a/src/outputs/__mocks__/values.ts
+++ b/src/outputs/__mocks__/values.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const valuesMap = new Map();
 
 const getValuesForOutputs = jest.fn()

--- a/src/outputs/__mocks__/write.ts
+++ b/src/outputs/__mocks__/write.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const writeOutputs = jest.fn()
   .mockName("outputs.writeOutputs");
 

--- a/src/outputs/index.ts
+++ b/src/outputs/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { OptimizedProjectStats, Outputter } from "./types";
 import type { error } from "../errors";
 

--- a/src/outputs/names.ts
+++ b/src/outputs/names.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 const enum OutputName {

--- a/src/outputs/types.d.ts
+++ b/src/outputs/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 interface OptimizedProjectStats {
   readonly optimizedCount: number;
   readonly svgCount: number;

--- a/src/outputs/values.ts
+++ b/src/outputs/values.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { OptimizedProjectStats } from "./types";
 
 import { OutputName } from "./names";

--- a/src/outputs/write.ts
+++ b/src/outputs/write.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { OutputName } from "./names";
 import type { Outputter } from "./types";
 

--- a/src/parsers/__mocks__/__common__.ts
+++ b/src/parsers/__mocks__/__common__.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const parsedObject = { };
 
 const parser = jest.fn()

--- a/src/parsers/__mocks__/builder.ts
+++ b/src/parsers/__mocks__/builder.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { parser } from "./__common__";
 
 const buildSafeParser = jest.fn()

--- a/src/parsers/__mocks__/eval.ts
+++ b/src/parsers/__mocks__/eval.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const parsedContent = { };
 
 const jsEval = jest.fn()

--- a/src/parsers/__mocks__/index.ts
+++ b/src/parsers/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { parser } from "./__common__";
 
 const NewJavaScript = jest.fn()

--- a/src/parsers/builder.ts
+++ b/src/parsers/builder.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { ParseFn, SafeParseFn } from "./types";
 import type { error } from "../errors";
 

--- a/src/parsers/eval.ts
+++ b/src/parsers/eval.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import _jsEval from "eval";
 
 function jsEval(raw: string) {

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SafeParseFn } from "./types";
 
 import { buildSafeParser } from "./builder";

--- a/src/parsers/types.d.ts
+++ b/src/parsers/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 type ParseFn<OutType> = (raw: string) => OutType;

--- a/src/svgo/__mocks__/__common__.ts
+++ b/src/svgo/__mocks__/__common__.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const optimizedSvgData = {
   data: "<svg></svg>",
 };

--- a/src/svgo/__mocks__/index.ts
+++ b/src/svgo/__mocks__/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { optimizer } from "./__common__";
 
 const New = jest.fn()

--- a/src/svgo/__mocks__/project.ts
+++ b/src/svgo/__mocks__/project.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { optimizer } from "./__common__";
 
 const createSvgoOptimizerForProject = jest.fn()

--- a/src/svgo/__mocks__/stub.ts
+++ b/src/svgo/__mocks__/stub.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { optimizer } from "./__common__";
 
 const StubSVGOptimizer = jest.fn()

--- a/src/svgo/index.ts
+++ b/src/svgo/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SupportedSvgoVersions, SVGOptimizer } from "./types";
 import type { error } from "../errors";
 

--- a/src/svgo/project.ts
+++ b/src/svgo/project.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SVGOptimizer } from "./types";
 import type { error } from "../errors";
 import type { SVGO as SVGOv2 } from "svgo-v2";

--- a/src/svgo/stub.ts
+++ b/src/svgo/stub.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 import errors from "../errors";

--- a/src/svgo/types.d.ts
+++ b/src/svgo/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../errors";
 
 type SupportedSvgoVersions =

--- a/src/svgo/v2/__mocks__/index.ts
+++ b/src/svgo/v2/__mocks__/index.ts
@@ -1,6 +1,6 @@
-/* eslint-disable jest/no-mocks-import */
+// SPDX-License-Identifier: MIT
 
-import { optimizer } from "../../__mocks__/__common__";
+import { optimizer } from "../../__mocks__/__common__"; // eslint-disable-line jest/no-mocks-import
 
 const New = jest.fn()
   .mockReturnValue([optimizer, null])

--- a/src/svgo/v2/__mocks__/wrapper.ts
+++ b/src/svgo/v2/__mocks__/wrapper.ts
@@ -1,6 +1,6 @@
-/* eslint-disable jest/no-mocks-import */
+// SPDX-License-Identifier: MIT
 
-import { optimizer } from "../../__mocks__/__common__";
+import { optimizer } from "../../__mocks__/__common__"; // eslint-disable-line jest/no-mocks-import
 
 const SvgoV2Wrapper = jest.fn()
   .mockReturnValue(optimizer)

--- a/src/svgo/v2/index.ts
+++ b/src/svgo/v2/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../../errors";
 import type { SVGOptimizer } from "../types";
 import type { SVGOptions } from "svgo-v2";

--- a/src/svgo/v2/svgo-v2.d.ts
+++ b/src/svgo/v2/svgo-v2.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 declare module "svgo-v2" {
   interface SVGO {
     optimize(svg: string, options: SVGOptions): {

--- a/src/svgo/v2/wrapper.ts
+++ b/src/svgo/v2/wrapper.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../../errors";
 import type { SVGO, SVGOptions } from "svgo-v2";
 

--- a/src/svgo/v3/__mocks__/index.ts
+++ b/src/svgo/v3/__mocks__/index.ts
@@ -1,6 +1,6 @@
-/* eslint-disable jest/no-mocks-import */
+// SPDX-License-Identifier: MIT
 
-import { optimizer } from "../../__mocks__/__common__";
+import { optimizer } from "../../__mocks__/__common__"; // eslint-disable-line jest/no-mocks-import
 
 const New = jest.fn()
   .mockReturnValue([optimizer, null])

--- a/src/svgo/v3/index.ts
+++ b/src/svgo/v3/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { error } from "../../errors";
 import type { SVGOptimizer } from "../types";
 import type { SVGO, SVGOptions } from "svgo-v2";

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Inputter } from "./inputs";
 import type { Outputter } from "./outputs";
 import type { GitHub as _GitHub } from "@actions/github/lib/utils";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 function len<T>(collection: Iterable<T>): number {
   return Array.from(collection).length;
 }

--- a/test/__common__/generate.ts
+++ b/test/__common__/generate.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { GitFileInfo } from "../../src/clients/types";
 
 function createFilesList(length: number): Iterable<GitFileInfo> {

--- a/test/__common__/inputter.mock.ts
+++ b/test/__common__/inputter.mock.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Inputter } from "../../src/inputs";
 
 type InputterMock = jest.Mocked<Inputter>;

--- a/test/__common__/node-fs.mock.ts
+++ b/test/__common__/node-fs.mock.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // https://nodejs.org/api/fs.html#fs_fs_existssync_path
 const existsSync = jest.fn()
   .mockReturnValue(false)

--- a/test/__common__/node-path.mock.ts
+++ b/test/__common__/node-path.mock.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // https://nodejs.org/api/path.html#path_path_resolve_paths
 const resolve = jest.fn()
   .mockImplementation((...args) => args.join("/"))

--- a/test/__common__/optimizer.mock.ts
+++ b/test/__common__/optimizer.mock.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Optimizer } from "../../src/optimize/types";
 
 type OptimizerMock = jest.Mocked<Optimizer>;

--- a/test/__common__/outputter.mock.ts
+++ b/test/__common__/outputter.mock.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Outputter } from "../../src/outputs";
 
 type OutputterMock = jest.Mocked<Outputter>;

--- a/test/integration/action-management.test.ts
+++ b/test/integration/action-management.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/core");
 
 import * as core from "@actions/core";

--- a/test/integration/clients.test.ts
+++ b/test/integration/clients.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { when, resetAllWhenMocks } from "jest-when";
 
 jest.mock("@actions/github");

--- a/test/integration/file-systems.test.ts
+++ b/test/integration/file-systems.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Dirent, Stats } from "node:fs";
 
 jest.mock("node:fs", () => require("../__common__/node-fs.mock.ts"));

--- a/test/integration/filters.test.ts
+++ b/test/integration/filters.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { PrContext } from "../../src/filters/pr-files";
 import type { PushContext } from "../../src/filters/pushed-files";
 import type { Mutable } from "../utils";

--- a/test/integration/helpers.test.ts
+++ b/test/integration/helpers.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Config } from "../../src/helpers/filters";
 import type { Octokit } from "../../src/types";
 import type { Mutable } from "../utils";

--- a/test/integration/inputs.test.ts
+++ b/test/integration/inputs.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { when, resetAllWhenMocks } from "jest-when";
 
 import inputs from "../../src/inputs";

--- a/test/integration/main.test.ts
+++ b/test/integration/main.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Dirent } from "node:fs";
 
 jest.mock("@actions/core");

--- a/test/integration/optimize.test.ts
+++ b/test/integration/optimize.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FileSystem } from "../../src/file-systems";
 
 import { when, resetAllWhenMocks } from "jest-when";

--- a/test/integration/outputs.test.ts
+++ b/test/integration/outputs.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import outputs from "../../src/outputs";
 import out from "../__common__/outputter.mock";
 

--- a/test/integration/parsers.test.ts
+++ b/test/integration/parsers.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.dontMock("eval");
 
 import parsers from "../../src/parsers";

--- a/test/integration/svgo.test.ts
+++ b/test/integration/svgo.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SupportedSvgoVersions } from "../../src/svgo";
 
 jest.dontMock("svgo-v2");

--- a/test/unit/action-management/action-manager.test.ts
+++ b/test/unit/action-management/action-manager.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/core");
 jest.mock("../../../src/action-management/helpers");
 jest.mock("../../../src/errors");

--- a/test/unit/action-management/helpers.test.ts
+++ b/test/unit/action-management/helpers.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("../../../src/errors");
 
 import {

--- a/test/unit/action-management/index.test.ts
+++ b/test/unit/action-management/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/core");
 jest.mock("../../../src/action-management/action-manager");
 

--- a/test/unit/clients/client.test.ts
+++ b/test/unit/clients/client.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/github");
 jest.mock("../../../src/errors");
 

--- a/test/unit/clients/index.test.ts
+++ b/test/unit/clients/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { GitHub } from "../../../src/clients/types";
 
 import { when, resetAllWhenMocks } from "jest-when";

--- a/test/unit/clients/stub.test.ts
+++ b/test/unit/clients/stub.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type {
   CommitsListFilesParams,
   PullsListFilesParams,

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import errors from "../../src/errors";
 
 describe("errors.ts", () => {

--- a/test/unit/file-systems/base.test.ts
+++ b/test/unit/file-systems/base.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Dirent, Stats } from "node:fs";
 
 import { when, resetAllWhenMocks } from "jest-when";

--- a/test/unit/file-systems/filtered.test.ts
+++ b/test/unit/file-systems/filtered.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FileFilter, FileSystem } from "../../../src/file-systems/types";
 
 import { when, resetAllWhenMocks } from "jest-when";

--- a/test/unit/file-systems/index.test.ts
+++ b/test/unit/file-systems/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("node:fs", () => require("../../__common__/node-fs.mock.ts"));
 jest.mock("node:path", () => require("../../__common__/node-path.mock.ts"));
 jest.mock("../../../src/file-systems/base");

--- a/test/unit/filters/glob.test.ts
+++ b/test/unit/filters/glob.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/glob");
 
 import { create } from "@actions/glob";

--- a/test/unit/filters/index.test.ts
+++ b/test/unit/filters/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/github");
 jest.mock("../../../src/clients");
 jest.mock("../../../src/filters/pr-files");

--- a/test/unit/filters/pr-files.test.ts
+++ b/test/unit/filters/pr-files.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { PrContext } from "../../../src/filters/pr-files";
 import type { Mutable } from "../../utils";
 

--- a/test/unit/filters/pushed-files.test.ts
+++ b/test/unit/filters/pushed-files.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { PushContext } from "../../../src/filters/pushed-files";
 import type { Mutable } from "../../utils";
 

--- a/test/unit/filters/svgs.test.ts
+++ b/test/unit/filters/svgs.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import New from "../../../src/filters/svgs";
 
 describe("filters/svgs.ts", () => {

--- a/test/unit/helpers/events.test.ts
+++ b/test/unit/helpers/events.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   isClientRequired,
   isEventSupported,

--- a/test/unit/helpers/filters.test.ts
+++ b/test/unit/helpers/filters.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { Config } from "../../../src/helpers/filters";
 import type { Mutable } from "../../utils";
 

--- a/test/unit/helpers/index.test.ts
+++ b/test/unit/helpers/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("../../../src/helpers/events");
 jest.mock("../../../src/helpers/filters");
 jest.mock("../../../src/helpers/svgo-config");

--- a/test/unit/helpers/svgo-config.test.ts
+++ b/test/unit/helpers/svgo-config.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("../../../src/errors");
 jest.mock("../../../src/parsers");
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/core");
 jest.mock("@actions/github");
 jest.mock("../../src/main");

--- a/test/unit/inputs/constants.test.ts
+++ b/test/unit/inputs/constants.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   INPUT_OPTIONS_NOT_REQUIRED,
   INPUT_OPTIONS_REQUIRED,

--- a/test/unit/inputs/getters.test.ts
+++ b/test/unit/inputs/getters.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { when, resetAllWhenMocks } from "jest-when";
 
 jest.mock("../../../src/errors");

--- a/test/unit/inputs/helpers.test.ts
+++ b/test/unit/inputs/helpers.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   getDefaultSvgoConfigPath,
 } from "../../../src/inputs/helpers";

--- a/test/unit/inputs/index.test.ts
+++ b/test/unit/inputs/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SupportedSvgoVersions } from "../../../src/svgo";
 
 jest.mock("../../../src/errors");

--- a/test/unit/main.test.ts
+++ b/test/unit/main.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("@actions/core");
 jest.mock("@actions/github");
 jest.mock("../../src/action-management");

--- a/test/unit/optimize/index.test.ts
+++ b/test/unit/optimize/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { FileSystem } from "../../../src/file-systems";
 
 import { when, resetAllWhenMocks } from "jest-when";

--- a/test/unit/outputs/index.test.ts
+++ b/test/unit/outputs/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { OutputName } from "../../../src/outputs/names";
 
 jest.mock("../../../src/errors");

--- a/test/unit/outputs/names.test.ts
+++ b/test/unit/outputs/names.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import {
   EVENT_PULL_REQUEST,
   EVENT_PUSH,

--- a/test/unit/outputs/values.test.ts
+++ b/test/unit/outputs/values.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { OutputName } from "../../../src/outputs/names";
 import {
   getValuesForOutputs,

--- a/test/unit/outputs/write.test.ts
+++ b/test/unit/outputs/write.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { OutputName } from "../../../src/outputs/names";
 
 import {

--- a/test/unit/parsers/builder.test.ts
+++ b/test/unit/parsers/builder.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("../../../src/errors");
 
 import {

--- a/test/unit/parsers/eval.test.ts
+++ b/test/unit/parsers/eval.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("eval");
 
 import _jsEval from "eval";

--- a/test/unit/parsers/index.test.ts
+++ b/test/unit/parsers/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("../../../src/parsers/builder");
 jest.mock("../../../src/parsers/eval");
 

--- a/test/unit/svgo/common.ts
+++ b/test/unit/svgo/common.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const invalidSvg = "<svg";
 
 const optimizedSvg = "<svg></svg>";

--- a/test/unit/svgo/index.test.ts
+++ b/test/unit/svgo/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SupportedSvgoVersions } from "../../../src/svgo";
 
 jest.mock("@actions/core");

--- a/test/unit/svgo/project.test.ts
+++ b/test/unit/svgo/project.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.dontMock("svgo-v2");
 jest.dontMock("svgo-v3");
 

--- a/test/unit/svgo/stub.test.ts
+++ b/test/unit/svgo/stub.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("../../../src/errors");
 
 import StubSVGOptimizer from "../../../src/svgo/stub";

--- a/test/unit/svgo/v2/index.test.ts
+++ b/test/unit/svgo/v2/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("svgo-v2");
 jest.mock("../../../../src/errors");
 jest.mock("../../../../src/svgo/v2/wrapper");

--- a/test/unit/svgo/v2/wrapper.test.ts
+++ b/test/unit/svgo/v2/wrapper.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import type { SVGO, SVGOptions } from "svgo-v2";
 
 import { when, resetAllWhenMocks } from "jest-when";

--- a/test/unit/svgo/v3/index.test.ts
+++ b/test/unit/svgo/v3/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 jest.mock("svgo-v3");
 jest.mock("../../../../src/errors");
 jest.mock("../../../../src/svgo/v2/wrapper");

--- a/test/utils.d.ts
+++ b/test/utils.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 export type Mutable<T> =
   T extends (undefined | null | boolean | string | number) ? T :
   T extends Array<infer U> ? U[] :


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

### Checklist

<!--
Please fill out this checklist to make sure you didn't forget anything. If
something isn't relevant you can remove it or cross it anyway.
-->

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Adopt [SPDX license IDs](https://spdx.dev/learn/handling-license-info/) as a way to specify at the file level what OSS license actually applies to that file. This is mostly relevant to "non-source code" files because even though most of these are already covered (not all, actually).

Some files are not included here because they're taken verbatim (or only slightly modified) from somewhere else, and for these files it's clear where it is taken from and under what license.
