### PR TITLE
Remove license IDs from GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,8 +4,6 @@ about: Report a problem with the SVGO Action.
 labels: bug
 ---
 
-<!-- SPDX-License-Identifier: CC0-1.0 -->
-
 # Bug Report
 
 <!-- The version of the Action you're using -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -4,8 +4,6 @@ about: Report problems with SVGO Action's documentation.
 labels: docs
 ---
 
-<!-- SPDX-License-Identifier: CC0-1.0 -->
-
 # Documentation
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,8 +4,6 @@ about: Request a feature for the SVGO Action.
 labels: enhancement
 ---
 
-<!-- SPDX-License-Identifier: CC0-1.0 -->
-
 # Feature Request
 
 <!-- The version of the Action you're using -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,8 +4,6 @@ about: Ask a question about the SVGO Action.
 labels: question
 ---
 
-<!-- SPDX-License-Identifier: CC0-1.0 -->
-
 # Question
 
 <!-- The version of the Action you're using -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-<!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- markdownlint-disable MD041-->
 
 ### Checklist


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

The license IDs are a bit weird when they appear when you're submitting an issue or Pull Request. While I like being explicit about the license under which they're available, I'm not a fan of this impacting contributions. I'm especially worried about any potential confusion or "fear" this might cause, leading to people refraining from contributing.

If you have suggestions for how to be explicit about the license these files are available under without it being visible when submitting an issue/Pull Request, please share it here :slightly_smiling_face: 

Relates to #882