### PR TITLE
Adopt new MarkDown extension for alerts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,9 @@ relevant sections of this document.
   - [Integration Testing](#integration-testing)
   - [End-to-End Testing](#end-to-end-testing)
 
-> **Note** If you want to make a contribution to v3 of the project, please refer
-> to the [Contributing Guidelines for v3].
+> [!NOTE]
+> If you want to make a contribution to v3 of the project, please refer to the
+> [Contributing Guidelines for v3].
 
 ---
 
@@ -90,10 +91,11 @@ When you open a Pull Request that implements an issue make sure to link to that
 issue in the Pull Request description and explain how you implemented the issue
 as clearly as possible.
 
-> **Note**: If you, for whatever reason, can not continue your work, please
-> share this in the issue or your Pull Request. This gives others an opportunity
-> to work on it. If we don't hear from you for an extended period of time we may
-> decide to allow others to work on the issue you were assigned to.
+> [!NOTE]
+> If you, for whatever reason, can not continue your work, please share this in
+> the issue or your Pull Request. This gives others an opportunity to work on
+> it. If we don't hear from you for an extended period of time we may decide to
+> allow others to work on the issue you were assigned to.
 
 ### Prerequisites
 
@@ -170,9 +172,10 @@ If you want to improve the code style, update the configuration file for the
 respective linter accordingly. If you need an extra package to be able to
 enforce your style, add it as a `devDependency`.
 
-> **Note**: Keep in mind that the developers of the project determine the code
-> style as they see fit. For this reason, take the time to explain why you think
-> your changes improve the project.
+> [!NOTE]
+> Keep in mind that the developers of the project determine the code style as
+> they see fit. For this reason, take the time to explain why you think your
+> changes improve the project.
 
 #### Vetting
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,9 +96,10 @@ version (using `v4.3.2` as an example):
 1. Merge the Pull Request if the changes look OK and all continuous integration
    checks are passing.
 
-   > **Note**: At this point, the continuous delivery automation may pick up and
-   > complete the release process. Check whether or not this happens. If no, or
-   > only partially, continue following the remaining steps.
+   > [!NOTE]
+   > At this point, the continuous delivery automation may pick up and complete
+   > the release process. Check whether or not this happens. If no, or only
+   > partially, continue following the remaining steps.
 
 1. Immediately after the Pull Request is merged, sync the `main` branch:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ Try to include as many of the following items as possible in a security report:
 
 ## Advisories
 
-> [!NOTE]
+> [!IMPORTANT]
 > Advisories will be created only for vulnerabilities present in released
 > versions of the project.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,8 +58,9 @@ Try to include as many of the following items as possible in a security report:
 
 ## Advisories
 
-> **Note**: Advisories will be created only for vulnerabilities present in
-> released versions of the project.
+> [!NOTE]
+> Advisories will be created only for vulnerabilities present in released
+> versions of the project.
 
 | ID               | Date       | Affected versions | Patched versions |
 | :--------------- | :--------- | :---------------- | :--------------- |

--- a/docs/events.md
+++ b/docs/events.md
@@ -17,7 +17,7 @@ to improve the documentation.
 
 ---
 
-> [!CAUTION]
+> [!IMPORTANT]
 > The Action will run on any event if [strict mode] is not enabled. However,
 > this is not officially supported so you may encounter unexpected behaviour.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -17,9 +17,9 @@ to improve the documentation.
 
 ---
 
-> **Warning**: The Action will run on any event if [strict mode] is not enabled.
-> However, this is not officially supported so you may encounter unexpected
-> behaviour.
+> [!CAUTION]
+> The Action will run on any event if [strict mode] is not enabled. However,
+> this is not officially supported so you may encounter unexpected behaviour.
 
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -72,8 +72,9 @@ there are no changes, nothing will be committed or commented.
 Check out [what the Action outputs] to customize the commit message and Pull
 Request comment to your liking.
 
-> **Warning**: This does not work for Pull Requests from forks. This is because
-> GitHub Actions do not have permission to alter forked repositories.
+> [!WARNING]
+> This does not work for Pull Requests from forks. This is because GitHub
+> Actions do not have permission to alter forked repositories.
 
 ```yml
 # .github/workflows/optimize.yml
@@ -273,9 +274,10 @@ repository was changed on `push` events. Even though this Action does nothing
 if a push (or Pull Request) touches no SVGs, you may want the Action to run only
 when an SVG has actually changed.
 
-> **Warning**: This will cause the entire Workflow to be run only when an SVG
-> changes. Jobs that should run for every push or Pull Request must be specified
-> in a separate Workflow file.
+> [!IMPORTANT]
+> This will cause the entire Workflow to be run only when an SVG changes. Jobs
+> that should run for every push or Pull Request must be specified in a separate
+> Workflow file.
 
 ```yml
 # .github/workflows/optimize.yml

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -26,7 +26,7 @@ The `dry-run` input can be used to run the Action without having it write any
 changes. This can be useful for debugging or when you just want to give the
 Action a try.
 
-> [!IMPORTANT]
+> [!NOTE]
 > If you misconfigure this input the Action assumes you wanted to enable it and
 > set `dry-run` to `true`.
 
@@ -129,7 +129,7 @@ The `strict` input can be used to enable _strict mode_. In strict mode, the
 Action will fail in the event of a non-critical error (instead of just in the
 event of a critical error).
 
-> [!IMPORTANT]
+> [!NOTE]
 > If you misconfigure this input the Action assumes you wanted to enable it and
 > set `strict` to `true`. This in turn results in the Action failing due to an
 > invalid input.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -26,8 +26,9 @@ The `dry-run` input can be used to run the Action without having it write any
 changes. This can be useful for debugging or when you just want to give the
 Action a try.
 
-> **Warning**: If you misconfigure this input the Action assumes you wanted to
-> enable it and set `dry-run` to `true`.
+> [!IMPORTANT]
+> If you misconfigure this input the Action assumes you wanted to enable it and
+> set `dry-run` to `true`.
 
 ### Examples
 
@@ -54,8 +55,9 @@ Action. By default, no files are ignored. The value is interpreted as a [glob],
 if there are multiple lines each line is interpreted as a [glob]. Any file that
 matches (any of) the configured glob(s) will **not** be optimized by the Action.
 
-> **Note**: Regardless of the value of this input, the Action will only consider
-> files with the `.svg` file extension.
+> [!NOTE]
+> Regardless of the value of this input, the Action will only consider files
+> with the `.svg` file extension.
 
 ### Examples
 
@@ -127,9 +129,10 @@ The `strict` input can be used to enable _strict mode_. In strict mode, the
 Action will fail in the event of a non-critical error (instead of just in the
 event of a critical error).
 
-> **Warning**: If you misconfigure this input the Action assumes you wanted to
-> enable it and set `strict` to `true`. This in turn results in the Action
-> failing due to an invalid input.
+> [!IMPORTANT]
+> If you misconfigure this input the Action assumes you wanted to enable it and
+> set `strict` to `true`. This in turn results in the Action failing due to an
+> invalid input.
 
 ### Examples
 


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] I updated the documentation according to my changes.
- [x] ~~I added my change to the Changelog.~~

### Description

Update the documentation following a [GitHub blog post](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/) today in order to adopt the new extension formatting for alerts.