### PR TITLE
Use lockfile-lint to vet `package-lock.json`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -490,6 +490,9 @@ jobs:
       - name: Vet dependencies
         if: ${{ failure() || success() }}
         run: npm run vet:deps
+      - name: Vet lockfile
+        if: ${{ failure() || success() }}
+        run: npm run vet:package-lock.json
       - name: Vet types
         if: ${{ failure() || success() }}
         run: npm run vet:types

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "jest-when": "3.6.0",
         "knip": "3.3.5",
         "licensee": "10.0.0",
+        "lockfile-lint": "4.12.1",
         "markdownlint-cli": "0.37.0",
         "rollup": "4.6.1",
         "ts-jest": "29.1.1",
@@ -3960,6 +3961,41 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@yarnpkg/parsers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0.tgz",
+      "integrity": "sha512-jVZa3njBv6tcOUw34nlUdUM/40wwtm/gnVF8rtk0tA6vNcokqYI8CFU1BZjlpFwUSZaXxYkrtuPE/f2MMFlTxQ==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.10.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/@zkochan/retry": {
       "version": "0.2.0",
@@ -9303,6 +9339,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lockfile-lint": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-4.12.1.tgz",
+      "integrity": "sha512-FBP7OA7sa45kzPgRNLYIcGGgDS86rpZNW3ptALp1vlzv+oHZsqFZdmHXM4N4FwiGXHzUOpSVvDLT4v7IiQXFtA==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^8.2.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.1",
+        "lockfile-lint-api": "^5.8.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "lockfile-lint": "bin/lockfile-lint.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/lockfile-lint-api": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/lockfile-lint-api/-/lockfile-lint-api-5.8.0.tgz",
+      "integrity": "sha512-RHa+ofSGMGQvPFG1oD2qZmSWF2MfxWXhle/unpzmDjpi8F8Ou5sreNUcAscgGRfcX+BszBuVKddD0X5YKQ0TeA==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/parsers": "^3.0.0-rc.32",
+        "debug": "^4.3.4",
+        "object-hash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -10710,6 +10779,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
     "test:mutation": "stryker run stryker.config.js",
     "test:unit": "jest test/unit",
     "verify": "npm run license-check && npm run lint && npm run test:unit && npm run vet",
-    "vet": "npm run vet:deps && npm run vet:types",
+    "vet": "npm run vet:deps && npm run vet:package-lock.json && npm run vet:types",
     "vet:deps": "knip --config .knip.jsonc",
+    "vet:package-lock.json": "lockfile-lint --path package-lock.json --allowed-hosts npm --validate-https",
     "vet:types": "type-coverage --at-least 100 --project tsconfig.json --strict"
   },
   "repository": {
@@ -111,6 +112,7 @@
     "jest-when": "3.6.0",
     "knip": "3.3.5",
     "licensee": "10.0.0",
+    "lockfile-lint": "4.12.1",
     "markdownlint-cli": "0.37.0",
     "rollup": "4.6.1",
     "ts-jest": "29.1.1",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Start vetting(/linting) the lockfile for problems. In particular, with the current configuration this checks that only listed sources are used for packages as well as that only https is used.
