### PR TITLE
chore(deps): bump SVGO from v3.1.0 to v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update SVGO v3 to `v3.2.0`. ([#926])
 
 ## [4.0.5] - 2024-01-01
 
@@ -618,5 +618,6 @@ Versioning].
 [#906]: https://github.com/ericcornelissen/svgo-action/pull/906
 [#916]: https://github.com/ericcornelissen/svgo-action/pull/916
 [#920]: https://github.com/ericcornelissen/svgo-action/pull/920
+[#926]: https://github.com/ericcornelissen/svgo-action/pull/926
 [64d0e89]: https://github.com/ericcornelissen/svgo-action/commit/64d0e8958d462695b3939588707815182ecc3690
 [8d8f516]: https://github.com/ericcornelissen/svgo-action/commit/8d8f516583b4340f692e2ea80e1855e5a1211bd3

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eval": "0.1.8",
         "import-cwd": "3.0.0",
         "svgo-v2": "npm:svgo@2.8.0",
-        "svgo-v3": "npm:svgo@3.1.0"
+        "svgo-v3": "npm:svgo@3.2.0"
       },
       "devDependencies": {
         "@commitlint/cli": "18.4.3",
@@ -13225,16 +13225,16 @@
     },
     "node_modules/svgo-v3": {
       "name": "svgo",
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.1.0.tgz",
-      "integrity": "sha512-R5SnNA89w1dYgNv570591F66v34b3eQShpIBcQtZtM5trJwm1VvxbIoMpRYY3ybTAutcKTLEmTsdnaknOHbiQA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
-        "css-tree": "^2.2.1",
+        "css-tree": "^2.3.1",
         "css-what": "^6.1.0",
-        "csso": "5.0.5",
+        "csso": "^5.0.5",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -13272,16 +13272,15 @@
       }
     },
     "node_modules/svgo-v3/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dependencies": {
-        "mdn-data": "2.0.28",
+        "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
       },
       "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/svgo-v3/node_modules/csso": {
@@ -13295,6 +13294,24 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/svgo-v3/node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/svgo-v3/node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
     "node_modules/svgo-v3/node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -13348,9 +13365,9 @@
       }
     },
     "node_modules/svgo-v3/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/table": {
       "version": "6.8.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eval": "0.1.8",
     "import-cwd": "3.0.0",
     "svgo-v2": "npm:svgo@2.8.0",
-    "svgo-v3": "npm:svgo@3.1.0"
+    "svgo-v3": "npm:svgo@3.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "18.4.3",


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] ~~I tested my changes.~~
- [x] ~~I updated the documentation according to my changes.~~
- [x] I added my change to the Changelog.

### Description

Upgrade SVGO v3 to the next available version, v3.2.0.

Closes https://github.com/ericcornelissen/svgo-action/issues/923