### PR TITLE
Fix missing space in deprecation warning

### DIFF
--- a/src/helpers/deprecation.ts
+++ b/src/helpers/deprecation.ts
@@ -12,7 +12,7 @@ function deprecationWarnings({
   core,
 }: Params): void {
   core.warning(
-    "Support for SVGO Action, in general, will end 2024-04-30. We recommend" +
+    "Support for SVGO Action, in general, will end 2024-04-30. We recommend " +
     "finding an alternative before then and to stop using this Action.",
   );
 }

--- a/test/unit/helpers/deprecation.test.ts
+++ b/test/unit/helpers/deprecation.test.ts
@@ -19,7 +19,7 @@ describe("helpers/deprecation.ts", () => {
     deprecationWarnings({ core });
     expect(core.warning).toHaveBeenCalledWith(
       "Support for SVGO Action, in general, will end 2024-04-30. We recommend" +
-      "finding an alternative before then and to stop using this Action.",
+      " finding an alternative before then and to stop using this Action.",
     );
   });
 });


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [ ] ~~I updated the documentation according to my changes.~~
- [ ] ~~I added my change to the Changelog.~~

### Description

Relates to #930

Fixes a typo in the deprecation warning. Unless requested I won't create a release just for this.