### PR TITLE
Fix Codecov integration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -201,6 +201,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.codecov.io:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             codecov.io:443
@@ -235,6 +236,8 @@ jobs:
       - name: Upload code coverage
         uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
         if: ${{ failure() || success() }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./_reports/coverage/${{ matrix.type }}/lcov.info
           flags: ${{ matrix.type }}


### PR DESCRIPTION
### Checklist

- [x] I left no linting errors in my changes.
- [x] I tested my changes.
- [x] ~~I updated the documentation according to my changes.~~
- [x] ~~I added my change to the Changelog.~~

### Description

Use `CODECOV_TOKEN` to fix the Codecov integration in CI. Add new egress endpoint for Codecov to ensure the integration works as expected.

This has been broken since the codecov/codecov-action was upgraded to v4.0.0